### PR TITLE
Fix URL typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bower install panoptes-client
 
 ### Using
 
-The Panoptes API is built on the very generically named [JSON API Spec](http://jsonapi.org/). This client leans heavily on [this library](github.com/brian-c/json-api-client) to make it easy to access different resources that the API offers.
+The Panoptes API is built on the very generically named [JSON API Spec](http://jsonapi.org/). This client leans heavily on [this library](https://github.com/brian-c/json-api-client) to make it easy to access different resources that the API offers.
 
 ### License
 


### PR DESCRIPTION
Noticed this link was taking you to github.com/zooniverse/panotpes-javascript-client/blob/master/github.com/brian-c/json-api-client which didn't seem right.