### PR TITLE
Use user.login instead of user.display_name

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -142,7 +142,7 @@ exports['default'] = function (panoptesClient) {
 
       return api.get('/me').then(function (response) {
         var user = response[0];
-        console.info('Got session', user.display_name, user.id);
+        console.info('Got session', user.login, user.id);
         return response[0];
       })['catch'](function (error) {
         console.error('Failed to get session');
@@ -157,24 +157,12 @@ exports['default'] = function (panoptesClient) {
         opts = {};
       }
 
-      var display_name = opts.display_name,
-          email = opts.email,
-          password = opts.password,
-          global_email_communication = opts.global_email_communication;
-
       return this.checkCurrent().then(function (user) {
         if ((0, _utils.exists)(user)) {
           return _this3.signOut().then(function () {
-            return _this3.register({
-              display_name: display_name,
-              email: email,
-              password: password,
-              global_email_communication: global_email_communication
-            });
+            return _this3.register(opts);
           });
         } else {
-          console.log('Registering new account', display_name);
-
           var registrationRequest = _this3._getAuthToken().then(function (token) {
             var data = {
               authenticity_token: token,
@@ -185,12 +173,10 @@ exports['default'] = function (panoptesClient) {
             return api.post('/../users', data, JSON_HEADERS).then(function () {
               return _this3._getBearerToken().then(function () {
                 return _this3._getSession().then(function (user) {
-                  console.info('Registered account', user.display_name, user.id);
                   return user;
                 });
               });
             })['catch'](function (error) {
-              console.error('Failed to register');
               throw error;
             });
           });
@@ -233,17 +219,12 @@ exports['default'] = function (panoptesClient) {
         opts = {};
       }
 
-      var display_name = opts.display_name,
-          password = opts.password;
-
       return this.checkCurrent().then(function (user) {
         if ((0, _utils.exists)(user)) {
           return _this5.signOut().then(function () {
             return _this5.signIn(opts);
           });
         } else {
-          console.log('Signing in', display_name);
-
           var signInRequest = _this5._getAuthToken().then(function (token) {
             var data = {
               authenticity_token: token,
@@ -253,7 +234,7 @@ exports['default'] = function (panoptesClient) {
             return makeHTTPRequest('POST', host + '/users/sign_in', data, JSON_HEADERS).then(function () {
               return _this5._getBearerToken().then(function () {
                 return _this5._getSession().then(function (user) {
-                  console.info('Signed in', user.display_name, user.id);
+                  console.info('Signed in', user.login, user.id);
                   return user;
                 });
               });

--- a/src/auth.js
+++ b/src/auth.js
@@ -123,7 +123,7 @@ export default function(panoptesClient) {
       return api.get('/me')
         .then(function(response) {
           let user = response[0];
-          console.info('Got session', user.display_name, user.id);
+          console.info('Got session', user.login, user.id);
           return response[0];
         })
         .catch(function(error) {
@@ -137,24 +137,12 @@ export default function(panoptesClient) {
         opts = {};
       }
 
-      let display_name = opts.display_name,
-          email = opts.email,
-          password = opts.password,
-          global_email_communication = opts.global_email_communication;
-
       return this.checkCurrent().then(user => {
         if (exists(user)) {
           return this.signOut().then(() => {
-            return this.register({
-              display_name: display_name,
-              email: email,
-              password: password,
-              global_email_communication: global_email_communication
-            });
+            return this.register(opts);
           });
         } else {
-          console.log('Registering new account', display_name);
-
           let registrationRequest = this._getAuthToken().then((token) => {
             let data = {
               authenticity_token: token,
@@ -166,13 +154,11 @@ export default function(panoptesClient) {
               .then(() => {
                 return this._getBearerToken().then(() => {
                   return this._getSession().then(function(user) {
-                    console.info('Registered account', user.display_name, user.id);
                     return user;
                   });
                 });
               })
               .catch(function(error) {
-                console.error('Failed to register');
                 throw(error);
               });
           });
@@ -211,17 +197,12 @@ export default function(panoptesClient) {
         opts = {};
       }
 
-      let display_name = opts.display_name,
-          password = opts.password;
-
       return this.checkCurrent().then((user) => {
         if (exists(user)) {
           return this.signOut().then(() => {
             return this.signIn(opts);
           });
         } else {
-          console.log('Signing in', display_name);
-
           let signInRequest = this._getAuthToken().then((token) => {
             let data = {
               authenticity_token: token,
@@ -232,7 +213,7 @@ export default function(panoptesClient) {
               .then(() => {
                 return this._getBearerToken().then(() => {
                   return this._getSession().then((user) => {
-                    console.info('Signed in', user.display_name, user.id);
+                    console.info('Signed in', user.login, user.id);
                     return user;
                   });
                 });

--- a/test/auth.js
+++ b/test/auth.js
@@ -2,8 +2,8 @@ let test = require('blue-tape'),
     { exists } = require('../lib/utils'),
     PanoptesClient = require('../lib/client');
 
-const TEST_NAME = 'TEST_' + (new Date).toISOString().replace(/\W/g, '_')
-const TEST_EMAIL = TEST_NAME.toLowerCase() + '@zooniverse.org'
+const TEST_LOGIN = 'TEST_' + (new Date).toISOString().replace(/\W/g, '_')
+const TEST_EMAIL = TEST_LOGIN.toLowerCase() + '@zooniverse.org'
 const TEST_PASSWORD = 'P@$$wørd'
 
 let { api } = new PanoptesClient({
@@ -31,7 +31,7 @@ test('Registering an account with no data fails', function(t) {
     })
     .catch((error) => {
       t.pass('An error should have been thrown.');
-      t.ok(error.message.match(/^display_name(.+)blank/mi), 'Display name error should mention "blank"');
+      t.ok(error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"');
       t.ok(error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"');
       t.ok(error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"');
     });
@@ -40,7 +40,7 @@ test('Registering an account with no data fails', function(t) {
 
 test('Registering an account with a short password fails', function(t) {
   const SHORT_PASSWORD_REGISTRATION = {
-    display_name: TEST_NAME + '_short_password',
+    login: TEST_LOGIN + '_short_password',
     email: TEST_EMAIL,
     password: TEST_PASSWORD.slice(0, 7)
   }
@@ -56,7 +56,7 @@ test('Registering an account with a short password fails', function(t) {
 
 test('Registering a new account works', function(t) {
   const GOOD_REGISTRATION = {
-    display_name: TEST_NAME,
+    login: TEST_LOGIN,
     email: TEST_EMAIL,
     password: TEST_PASSWORD
   }
@@ -64,7 +64,7 @@ test('Registering a new account works', function(t) {
   return auth.register(GOOD_REGISTRATION)
     .then(function(user) {
       t.ok(exists(user), 'Should have gotten the new user');
-      t.ok(user.display_name == TEST_NAME, 'Display_name should be whatever display_name was given');
+      t.ok(user.login == TEST_LOGIN, 'Login should be whatever login was given');
     });
 });
 
@@ -73,7 +73,7 @@ test('Registering keeps you signed in', function(t) {
   return auth.checkCurrent()
     .then(function(user) {
       t.ok(exists(user), 'Should have gotten a user');
-      t.ok(user.display_name == TEST_NAME, 'Display_name should be whatever display_name was given');
+      t.ok(user.login == TEST_LOGIN, 'Login should be whatever login was given');
     });
 });
 
@@ -84,26 +84,26 @@ test('Sign out', function(t) {
     });
 });
 
-test('Registering an account with an already used display_name fails', function(t) {
+test('Registering an account with an already used login fails', function(t) {
   const DUPLICATE_REGISTRATION = {
-    display_name: TEST_NAME,
+    login: TEST_LOGIN,
     email: TEST_EMAIL,
     password: TEST_PASSWORD
   }
 
   return auth.register(DUPLICATE_REGISTRATION)
     .then(function() {
-      t.fail('Should not have been able to register with a duplicate display_name');
+      t.fail('Should not have been able to register with a duplicate login');
     })
     .catch(function(error) {
-      t.ok(error.message.match(/^display_name(.+)taken/mi), 'Display name error should mention "taken"');
+      t.ok(error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"');
       t.ok(error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"');
     });
 });
 
 test('Signing in with an unknown login fails', function(t) {
   const BAD_LOGIN = {
-    display_name: 'NOT_' + TEST_NAME,
+    login: 'NOT_' + TEST_LOGIN,
     password: TEST_PASSWORD
   }
 
@@ -120,7 +120,7 @@ test('Signing in with an unknown login fails', function(t) {
 
 test('Signing in with the wrong password fails', function(t) {
   const BAD_PASSWORD = {
-    display_name: TEST_NAME,
+    login: TEST_LOGIN,
     password: 'NOT_' + TEST_PASSWORD
   }
 
@@ -135,14 +135,14 @@ test('Signing in with the wrong password fails', function(t) {
 
 test('Signing in with good details works', function(t) {
   const GOOD_LOGIN_DETAILS = {
-    display_name: TEST_NAME,
+    login: TEST_LOGIN,
     password: TEST_PASSWORD
   }
 
   return auth.signIn(GOOD_LOGIN_DETAILS)
     .then(function(user) {
       t.ok(exists(user), 'Should have gotten a user');
-      t.ok(user.display_name == TEST_NAME, 'Display name should be the original');
+      t.ok(user.login == TEST_LOGIN, 'Login should be the original');
     })
 });
 
@@ -150,7 +150,7 @@ test('Disabling an account works', function(t) {
   return auth.disableAccount()
     .then(function() {
       const OLD_LOGIN_DETAILS = {
-        display_name: TEST_NAME,
+        login: TEST_LOGIN,
         password: TEST_PASSWORD
       }
 


### PR DESCRIPTION
- Related to #8 
- Panoptes recently changed to using `user.login` over `user.display_name` as the canonical, unique form by which users are referenced. This brings the client up to date.