### PR TITLE
Match bower.json version with package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "panoptes-client",
   "main": "./dist/panoptes-client.js",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "authors": [
     "Zooniverse"
   ],


### PR DESCRIPTION
The version number in `bower.json` is behind that in `package.json`. This brings it up to date; we'll probably need to delete the previous 0.1.2 tag and tag this commit instead.