### PR TITLE
Add OAuth sign in

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -234,7 +234,7 @@ module.exports = new Model({
     }.bind(this));
   },
 
-  signInWithOAuthRedirect: function (args) {
+  signInWithOAuthRedirect: function (args, window) {
     // Check to see if we're running in the browser or not
     if (typeof window === 'undefined') {
       throw new Error('OAuth login is only available via the browser.')

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -61,7 +61,10 @@ module.exports = new Model({
   },
 
   _handleNewBearerToken: function(request) {
-    var response = JSON.parse(request.text);
+    // If we already have the token and expiry, it's not JSON
+    var response = (request.access_token && request.expires_in)
+      ? request
+      : JSON.parse(request.text);
 
     this._bearerToken = response.access_token;
     apiClient.headers.Authorization = 'Bearer ' + this._bearerToken;
@@ -229,6 +232,47 @@ module.exports = new Model({
         return signInRequest;
       }
     }.bind(this));
+  },
+
+  signInWithOAuthRedirect: function (args) {
+    // Check to see if we're running in the browser or not
+    if (typeof window === 'undefined') {
+      throw new Error('OAuth login is only available via the browser.')
+    } else if (!args.appId) {
+      throw new Error('You need to specify an app ID.');
+    } else if (!args.redirectUri) {
+      throw new Error('You need to specify a URI to redirect to after authorization.');
+    }
+
+    var originalArguments = arguments;
+    return this.checkCurrent().then(function(user) {
+      if (user) {
+        return this.signOut().then(function() {
+          return this.signIn.apply(this, originalArguments);
+        }.bind(this));
+      } else {
+        console.log('Signing in with OAuth (redirect)');
+        var url = [
+          config.host,
+          '/oauth/authorize',
+          '?response_type=token',
+          '&client_id=',
+          args.appId,
+          '&redirect_uri=',
+          args.redirectUri
+        ].join('');
+        window.location.href = url;
+      }
+    }.bind(this));
+  },
+
+  completeSignInWithOAuth: function (args) {
+    this._handleNewBearerToken(args);
+    return this._getSession()
+      .then(function(user) {
+        console.info('Signed in', user.login, user.id);
+        return user;
+      }.bind(this));
   },
 
   changePassword: function(given) {

--- a/test/auth.js
+++ b/test/auth.js
@@ -7,149 +7,149 @@ var TEST_LOGIN = 'TEST_' + new Date().toISOString().replace(/\W/g, '_');
 var TEST_EMAIL = TEST_LOGIN.toLowerCase() + '@zooniverse.org';
 var TEST_PASSWORD = 'P@$$wørd';
 
-// test('Checking the current user initially fails', function(t) {
-//   return auth.checkCurrent()
-//     .then(function(user) {
-//       if (user) {
-//         t.fail('Nobody should be signed in');
-//       } else {
-//         t.pass('Nobody is signed in');
-//       }
-//     });
-// });
+test('Checking the current user initially fails', function(t) {
+  return auth.checkCurrent()
+    .then(function(user) {
+      if (user) {
+        t.fail('Nobody should be signed in');
+      } else {
+        t.pass('Nobody is signed in');
+      }
+    });
+});
 
-// test('Registering an account with no data fails', function(t) {
-//   var BLANK_REGISTRATION = {};
-//   return auth.register(BLANK_REGISTRATION)
-//     .then(function() {
-//       t.fail('Should not have been able to register');
-//     })
-//     .catch(function(error) {
-//       t.pass('An error should have been thrown.');
-//       t.ok(error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"');
-//       t.ok(error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"');
-//       t.ok(error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"');
-//     });
-// });
+test('Registering an account with no data fails', function(t) {
+  var BLANK_REGISTRATION = {};
+  return auth.register(BLANK_REGISTRATION)
+    .then(function() {
+      t.fail('Should not have been able to register');
+    })
+    .catch(function(error) {
+      t.pass('An error should have been thrown.');
+      t.ok(error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"');
+      t.ok(error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"');
+      t.ok(error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"');
+    });
+});
 
-// test('Registering an account with a short password fails', function(t) {
-//   var SHORT_PASSWORD_REGISTRATION = {
-//     login: TEST_LOGIN + '_short_password',
-//     email: TEST_EMAIL,
-//     password: TEST_PASSWORD.slice(0, 7),
-//   };
-//   return auth.register(SHORT_PASSWORD_REGISTRATION)
-//     .then(function() {
-//       t.fail('Should not have been able to register');
-//     })
-//     .catch(function(error) {
-//       t.ok(error.message.match(/^password(.+)short/mi), 'Password error should mention "short"');
-//     });
-// });
+test('Registering an account with a short password fails', function(t) {
+  var SHORT_PASSWORD_REGISTRATION = {
+    login: TEST_LOGIN + '_short_password',
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD.slice(0, 7),
+  };
+  return auth.register(SHORT_PASSWORD_REGISTRATION)
+    .then(function() {
+      t.fail('Should not have been able to register');
+    })
+    .catch(function(error) {
+      t.ok(error.message.match(/^password(.+)short/mi), 'Password error should mention "short"');
+    });
+});
 
-// test('Registering a new account works', function(t) {
-//   var GOOD_REGISTRATION = {
-//     login: TEST_LOGIN,
-//     email: TEST_EMAIL,
-//     password: TEST_PASSWORD,
-//   };
-//   return auth.register(GOOD_REGISTRATION)
-//     .then(function(user) {
-//       t.ok(user, 'Should have gotten the new user');
-//       t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
-//     });
-// });
+test('Registering a new account works', function(t) {
+  var GOOD_REGISTRATION = {
+    login: TEST_LOGIN,
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD,
+  };
+  return auth.register(GOOD_REGISTRATION)
+    .then(function(user) {
+      t.ok(user, 'Should have gotten the new user');
+      t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
+    });
+});
 
-// test('Registering keeps you signed in', function(t) {
-//   return auth.checkCurrent()
-//     .then(function(user) {
-//       t.ok(user, 'Should have gotten a user');
-//       t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
-//     });
-// });
+test('Registering keeps you signed in', function(t) {
+  return auth.checkCurrent()
+    .then(function(user) {
+      t.ok(user, 'Should have gotten a user');
+      t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
+    });
+});
 
-// test('Sign out', function(t) {
-//   return auth.signOut()
-//     .then(function() {
-//       t.pass('Signed out');
-//     });
-// });
+test('Sign out', function(t) {
+  return auth.signOut()
+    .then(function() {
+      t.pass('Signed out');
+    });
+});
 
-// test('Registering an account with an already used login fails', function(t) {
-//   var DUPLICATE_REGISTRATION = {
-//     login: TEST_LOGIN,
-//     email: TEST_EMAIL,
-//     password: TEST_PASSWORD,
-//   };
-//   return auth.register(DUPLICATE_REGISTRATION)
-//     .then(function() {
-//       t.fail('Should not have been able to register with a duplicate login');
-//     })
-//     .catch(function(error) {
-//       t.ok(error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"');
-//       t.ok(error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"');
-//     });
-// });
+test('Registering an account with an already used login fails', function(t) {
+  var DUPLICATE_REGISTRATION = {
+    login: TEST_LOGIN,
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD,
+  };
+  return auth.register(DUPLICATE_REGISTRATION)
+    .then(function() {
+      t.fail('Should not have been able to register with a duplicate login');
+    })
+    .catch(function(error) {
+      t.ok(error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"');
+      t.ok(error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"');
+    });
+});
 
-// test('Signing in with an unknown login fails', function(t) {
-//   var BAD_LOGIN = {
-//     login: 'NOT_' + TEST_LOGIN,
-//     password: TEST_PASSWORD,
-//   };
-//   return auth.signIn(BAD_LOGIN)
-//     .then(function() {
-//       t.fail('Should not have been able to sign in with a bad login');
-//     })
-//     .catch(function(error) {
-//       // NOTE: A bad login should return the same error as a bad password.
-//       t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
-//     });
-// });
+test('Signing in with an unknown login fails', function(t) {
+  var BAD_LOGIN = {
+    login: 'NOT_' + TEST_LOGIN,
+    password: TEST_PASSWORD,
+  };
+  return auth.signIn(BAD_LOGIN)
+    .then(function() {
+      t.fail('Should not have been able to sign in with a bad login');
+    })
+    .catch(function(error) {
+      // NOTE: A bad login should return the same error as a bad password.
+      t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
+    });
+});
 
-// test('Signing in with the wrong password fails', function(t) {
-//   var BAD_PASSWORD = {
-//     login: TEST_LOGIN,
-//     password: 'NOT_' + TEST_PASSWORD,
-//   };
-//   return auth.signIn(BAD_PASSWORD)
-//     .then(function() {
-//       t.fail('Should not have been able to sign in with a bad password');
-//     })
-//     .catch(function(error) {
-//       t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
-//     });
-// });
+test('Signing in with the wrong password fails', function(t) {
+  var BAD_PASSWORD = {
+    login: TEST_LOGIN,
+    password: 'NOT_' + TEST_PASSWORD,
+  };
+  return auth.signIn(BAD_PASSWORD)
+    .then(function() {
+      t.fail('Should not have been able to sign in with a bad password');
+    })
+    .catch(function(error) {
+      t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
+    });
+});
 
-// test('Signing in with good details works', function(t) {
-//   var GOOD_LOGIN_DETAILS = {
-//     login: TEST_LOGIN,
-//     password: TEST_PASSWORD,
-//   };
-//   return auth.signIn(GOOD_LOGIN_DETAILS)
-//     .then(function(user) {
-//       t.ok(user, 'Should have gotten a user');
-//       t.ok(user.login == TEST_LOGIN, 'Login should be the original');
-//     });
-// });
+test('Signing in with good details works', function(t) {
+  var GOOD_LOGIN_DETAILS = {
+    login: TEST_LOGIN,
+    password: TEST_PASSWORD,
+  };
+  return auth.signIn(GOOD_LOGIN_DETAILS)
+    .then(function(user) {
+      t.ok(user, 'Should have gotten a user');
+      t.ok(user.login == TEST_LOGIN, 'Login should be the original');
+    });
+});
 
-// test('Disabling an account works', function(t) {
-//   return auth.disableAccount()
-//     .then(function() {
-//       var OLD_LOGIN_DETAILS = {
-//         login: TEST_LOGIN,
-//         password: TEST_PASSWORD,
-//       };
-//       return auth.signIn(OLD_LOGIN_DETAILS)
-//         .then(function(user) {
-//           t.fail('Should not have been able to sign in to a disabled account');
-//         })
-//         .catch(function() {
-//           t.pass('Could not sign in to a disabled account');
-//         });
-//     });
-// });
+test('Disabling an account works', function(t) {
+  return auth.disableAccount()
+    .then(function() {
+      var OLD_LOGIN_DETAILS = {
+        login: TEST_LOGIN,
+        password: TEST_PASSWORD,
+      };
+      return auth.signIn(OLD_LOGIN_DETAILS)
+        .then(function(user) {
+          t.fail('Should not have been able to sign in to a disabled account');
+        })
+        .catch(function() {
+          t.pass('Could not sign in to a disabled account');
+        });
+    });
+});
 
-test('Signing in with OAuth works', function(t) {
+test('First step of signin with OAuth works', function(t) {
   t.plan(2);
   t.throws(auth.signInWithOAuthRedirect, 'Should not work outside the browser');
 
@@ -174,11 +174,9 @@ test('Signing in with OAuth works', function(t) {
     }
   };
 
-  (function (window) {
-    console.log(window)
-    auth.signInWithOAuthRedirect(GOOD_OAUTH_LOGIN_DETAILS);
-    // t.equal();
-  })(windowMock);
-
+  return auth.signInWithOAuthRedirect(GOOD_OAUTH_LOGIN_DETAILS, windowMock)
+    .then(function () {
+      t.equal(windowMock.location.href, url, 'Should have been taken to the OAuth login page');
+    });
 
 });

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,148 +1,184 @@
 var test = require('blue-tape');
+
 var auth = require('../lib/auth');
+var config = require('../lib/config');
 
 var TEST_LOGIN = 'TEST_' + new Date().toISOString().replace(/\W/g, '_');
 var TEST_EMAIL = TEST_LOGIN.toLowerCase() + '@zooniverse.org';
 var TEST_PASSWORD = 'P@$$wørd';
 
-test('Checking the current user initially fails', function(t) {
-  return auth.checkCurrent()
-    .then(function(user) {
-      if (user) {
-        t.fail('Nobody should be signed in');
-      } else {
-        t.pass('Nobody is signed in');
-      }
-    });
-});
+// test('Checking the current user initially fails', function(t) {
+//   return auth.checkCurrent()
+//     .then(function(user) {
+//       if (user) {
+//         t.fail('Nobody should be signed in');
+//       } else {
+//         t.pass('Nobody is signed in');
+//       }
+//     });
+// });
 
-test('Registering an account with no data fails', function(t) {
-  var BLANK_REGISTRATION = {};
-  return auth.register(BLANK_REGISTRATION)
-    .then(function() {
-      t.fail('Should not have been able to register');
-    })
-    .catch(function(error) {
-      t.pass('An error should have been thrown.');
-      t.ok(error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"');
-      t.ok(error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"');
-      t.ok(error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"');
-    });
-});
+// test('Registering an account with no data fails', function(t) {
+//   var BLANK_REGISTRATION = {};
+//   return auth.register(BLANK_REGISTRATION)
+//     .then(function() {
+//       t.fail('Should not have been able to register');
+//     })
+//     .catch(function(error) {
+//       t.pass('An error should have been thrown.');
+//       t.ok(error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"');
+//       t.ok(error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"');
+//       t.ok(error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"');
+//     });
+// });
 
-test('Registering an account with a short password fails', function(t) {
-  var SHORT_PASSWORD_REGISTRATION = {
-    login: TEST_LOGIN + '_short_password',
-    email: TEST_EMAIL,
-    password: TEST_PASSWORD.slice(0, 7),
+// test('Registering an account with a short password fails', function(t) {
+//   var SHORT_PASSWORD_REGISTRATION = {
+//     login: TEST_LOGIN + '_short_password',
+//     email: TEST_EMAIL,
+//     password: TEST_PASSWORD.slice(0, 7),
+//   };
+//   return auth.register(SHORT_PASSWORD_REGISTRATION)
+//     .then(function() {
+//       t.fail('Should not have been able to register');
+//     })
+//     .catch(function(error) {
+//       t.ok(error.message.match(/^password(.+)short/mi), 'Password error should mention "short"');
+//     });
+// });
+
+// test('Registering a new account works', function(t) {
+//   var GOOD_REGISTRATION = {
+//     login: TEST_LOGIN,
+//     email: TEST_EMAIL,
+//     password: TEST_PASSWORD,
+//   };
+//   return auth.register(GOOD_REGISTRATION)
+//     .then(function(user) {
+//       t.ok(user, 'Should have gotten the new user');
+//       t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
+//     });
+// });
+
+// test('Registering keeps you signed in', function(t) {
+//   return auth.checkCurrent()
+//     .then(function(user) {
+//       t.ok(user, 'Should have gotten a user');
+//       t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
+//     });
+// });
+
+// test('Sign out', function(t) {
+//   return auth.signOut()
+//     .then(function() {
+//       t.pass('Signed out');
+//     });
+// });
+
+// test('Registering an account with an already used login fails', function(t) {
+//   var DUPLICATE_REGISTRATION = {
+//     login: TEST_LOGIN,
+//     email: TEST_EMAIL,
+//     password: TEST_PASSWORD,
+//   };
+//   return auth.register(DUPLICATE_REGISTRATION)
+//     .then(function() {
+//       t.fail('Should not have been able to register with a duplicate login');
+//     })
+//     .catch(function(error) {
+//       t.ok(error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"');
+//       t.ok(error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"');
+//     });
+// });
+
+// test('Signing in with an unknown login fails', function(t) {
+//   var BAD_LOGIN = {
+//     login: 'NOT_' + TEST_LOGIN,
+//     password: TEST_PASSWORD,
+//   };
+//   return auth.signIn(BAD_LOGIN)
+//     .then(function() {
+//       t.fail('Should not have been able to sign in with a bad login');
+//     })
+//     .catch(function(error) {
+//       // NOTE: A bad login should return the same error as a bad password.
+//       t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
+//     });
+// });
+
+// test('Signing in with the wrong password fails', function(t) {
+//   var BAD_PASSWORD = {
+//     login: TEST_LOGIN,
+//     password: 'NOT_' + TEST_PASSWORD,
+//   };
+//   return auth.signIn(BAD_PASSWORD)
+//     .then(function() {
+//       t.fail('Should not have been able to sign in with a bad password');
+//     })
+//     .catch(function(error) {
+//       t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
+//     });
+// });
+
+// test('Signing in with good details works', function(t) {
+//   var GOOD_LOGIN_DETAILS = {
+//     login: TEST_LOGIN,
+//     password: TEST_PASSWORD,
+//   };
+//   return auth.signIn(GOOD_LOGIN_DETAILS)
+//     .then(function(user) {
+//       t.ok(user, 'Should have gotten a user');
+//       t.ok(user.login == TEST_LOGIN, 'Login should be the original');
+//     });
+// });
+
+// test('Disabling an account works', function(t) {
+//   return auth.disableAccount()
+//     .then(function() {
+//       var OLD_LOGIN_DETAILS = {
+//         login: TEST_LOGIN,
+//         password: TEST_PASSWORD,
+//       };
+//       return auth.signIn(OLD_LOGIN_DETAILS)
+//         .then(function(user) {
+//           t.fail('Should not have been able to sign in to a disabled account');
+//         })
+//         .catch(function() {
+//           t.pass('Could not sign in to a disabled account');
+//         });
+//     });
+// });
+
+test('Signing in with OAuth works', function(t) {
+  t.plan(2);
+  t.throws(auth.signInWithOAuthRedirect, 'Should not work outside the browser');
+
+  var GOOD_OAUTH_LOGIN_DETAILS = {
+    appId: '24ad5676d5d25c6aa850dc5d5f63ec8c03dbc7ae113b6442b8571fce6c5b974c',
+    redirectUri: 'http://localhost',
   };
-  return auth.register(SHORT_PASSWORD_REGISTRATION)
-    .then(function() {
-      t.fail('Should not have been able to register');
-    })
-    .catch(function(error) {
-      t.ok(error.message.match(/^password(.+)short/mi), 'Password error should mention "short"');
-    });
-});
 
-test('Registering a new account works', function(t) {
-  var GOOD_REGISTRATION = {
-    login: TEST_LOGIN,
-    email: TEST_EMAIL,
-    password: TEST_PASSWORD,
+  var url = [
+    config.host,
+    '/oauth/authorize',
+    '?response_type=token',
+    '&client_id=',
+    GOOD_OAUTH_LOGIN_DETAILS.appId,
+    '&redirect_uri=',
+    GOOD_OAUTH_LOGIN_DETAILS.redirectUri
+  ].join('');
+
+  var windowMock = {
+    location: {
+      href: ''
+    }
   };
-  return auth.register(GOOD_REGISTRATION)
-    .then(function(user) {
-      t.ok(user, 'Should have gotten the new user');
-      t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
-    });
-});
 
-test('Registering keeps you signed in', function(t) {
-  return auth.checkCurrent()
-    .then(function(user) {
-      t.ok(user, 'Should have gotten a user');
-      t.equal(user.login, TEST_LOGIN, 'Login should be whatever login was given');
-    });
-});
+  (function (window) {
+    console.log(window)
+    auth.signInWithOAuthRedirect(GOOD_OAUTH_LOGIN_DETAILS);
+    // t.equal();
+  })(windowMock);
 
-test('Sign out', function(t) {
-  return auth.signOut()
-    .then(function() {
-      t.pass('Signed out');
-    });
-});
 
-test('Registering an account with an already used login fails', function(t) {
-  var DUPLICATE_REGISTRATION = {
-    login: TEST_LOGIN,
-    email: TEST_EMAIL,
-    password: TEST_PASSWORD,
-  };
-  return auth.register(DUPLICATE_REGISTRATION)
-    .then(function() {
-      t.fail('Should not have been able to register with a duplicate login');
-    })
-    .catch(function(error) {
-      t.ok(error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"');
-      t.ok(error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"');
-    });
-});
-
-test('Signing in with an unknown login fails', function(t) {
-  var BAD_LOGIN = {
-    login: 'NOT_' + TEST_LOGIN,
-    password: TEST_PASSWORD,
-  };
-  return auth.signIn(BAD_LOGIN)
-    .then(function() {
-      t.fail('Should not have been able to sign in with a bad login');
-    })
-    .catch(function(error) {
-      // NOTE: A bad login should return the same error as a bad password.
-      t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
-    });
-});
-
-test('Signing in with the wrong password fails', function(t) {
-  var BAD_PASSWORD = {
-    login: TEST_LOGIN,
-    password: 'NOT_' + TEST_PASSWORD,
-  };
-  return auth.signIn(BAD_PASSWORD)
-    .then(function() {
-      t.fail('Should not have been able to sign in with a bad password');
-    })
-    .catch(function(error) {
-      t.ok(error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"');
-    });
-});
-
-test('Signing in with good details works', function(t) {
-  var GOOD_LOGIN_DETAILS = {
-    login: TEST_LOGIN,
-    password: TEST_PASSWORD,
-  };
-  return auth.signIn(GOOD_LOGIN_DETAILS)
-    .then(function(user) {
-      t.ok(user, 'Should have gotten a user');
-      t.ok(user.login == TEST_LOGIN, 'Login should be the original');
-    });
-});
-
-test('Disabling an account works', function(t) {
-  return auth.disableAccount()
-    .then(function() {
-      var OLD_LOGIN_DETAILS = {
-        login: TEST_LOGIN,
-        password: TEST_PASSWORD,
-      };
-      return auth.signIn(OLD_LOGIN_DETAILS)
-        .then(function(user) {
-          t.fail('Should not have been able to sign in to a disabled account');
-        })
-        .catch(function() {
-          t.pass('Could not sign in to a disabled account');
-        });
-    });
 });


### PR DESCRIPTION
Adds the `signInWithOAuthRedirect` method to the auth module, allowing in-browser authentication via OAuth. I've named the method to allow for a future popup implementation as well.

To do:
- [x] Write OAuth sign in method
- [ ] Write tests

cc @brian-c 