### PR TITLE
Fixed `env` variable in lib/config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -38,10 +38,10 @@ var envFromShell = process.env.NODE_ENV;
 var env = envFromBrowser || envFromShell || DEFAULT_ENV;
 
 module.exports = {
-  host: hostFromBrowser || hostFromShell || API_HOSTS[env],
-  clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env],
-  talkHost: talkFromBrowser || talkFromShell || TALK_HOSTS[env],
-  sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
+  host: hostFromBrowser || hostFromShell || API_HOSTS[env] || API_HOSTS[DEFAULT_ENV],
+  clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env] || API_APPLICATION_IDS[DEFAULT_ENV],
+  talkHost: talkFromBrowser || talkFromShell || TALK_HOSTS[env] || TALK_HOSTS[DEFAULT_ENV],
+  sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env] || SUGAR_HOSTS[DEFAULT_ENV],
 };
 
 // Try and match the location.search property against a regex. Basically mimics


### PR DESCRIPTION
### Bugfix: 'env' variable in config.js was returning invalid values.

Symptoms:
* When using the Panoptes client in apps, the app will sometimes - depending on the process environment - throw an error, notably `Uncaught SugarClient.host is not defined`
* See: https://github.com/zooniverse/wildcam-gorongosa-education/pull/22#issuecomment-179395232

Analysis:
* We've detected that the `env` variable in lib/config.js doesn't always have one the valid values, i.e. 'production', 'staging' or 'cam'.
* In certain environments, the value of `env` is 'development' or something similarly invalid. This is the result of different Node setups whent this line is called:
```
var envFromShell = process.env.NODE_ENV;
```
* This will cause a chain reaction with the rest of the code...
```
//...
var envFromBrowser = locationMatch(/\W?env=(\w+)/);
var envFromShell = process.env.NODE_ENV;
var env = envFromBrowser || envFromShell || DEFAULT_ENV;

module.exports = {
  host: hostFromBrowser || hostFromShell || API_HOSTS[env],  //env can be invalid here
  clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env],  //and here
  talkHost: talkFromBrowser || talkFromShell || TALK_HOSTS[env],  //etc
  sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
};
//...
```

Actions:
* Recommendation: add additional fallbacks or a value whitelist so the `env` var cannot be invalid.
* This PR adds API_HOSTS[DEFAULT_ENV] (and similar) to the module.exports block as a fallback.

@brian-c , can you please take a look at this? Also: thanks to @rogerhutchings for shaping this fix.