### PR TITLE
Alternate fix for `env` variable in lib/config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -38,8 +38,8 @@ var envFromShell = process.env.NODE_ENV;
 var env = envFromBrowser || envFromShell || DEFAULT_ENV;
 
 if (!env.match(/^(production|staging|cam)$/)) { 
-  throw 'Panoptes Javascript Client Error: Invalid Environment; ' +
-    'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".';
+  throw new Error('Panoptes Javascript Client Error: Invalid Environment; ' +
+    'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".');
 }
 
 module.exports = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,6 +37,11 @@ var envFromShell = process.env.NODE_ENV;
 
 var env = envFromBrowser || envFromShell || DEFAULT_ENV;
 
+if (!env.match(/^(production|staging|cam)$/)) { 
+  throw 'Panoptes Javascript Client Error: Invalid Environment; ' +
+    'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".';
+}
+
 module.exports = {
   host: hostFromBrowser || hostFromShell || API_HOSTS[env],
   clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env],


### PR DESCRIPTION
### Bugfix: 'env' variable in config.js was returning invalid values.

This PR (a whitelist+fail dangerous fix) is an alternative to PR #22 (a fallback+failsafe fix). Please close PR #22 if this PR is merged, or vice versa.

Symptoms:
* When using the Panoptes client in apps, the app will sometimes - depending on the process environment - throw an error, notably `Uncaught SugarClient.host is not defined`
* See: https://github.com/zooniverse/wildcam-gorongosa-education/pull/22#issuecomment-179395232

Analysis:
* We've detected that the `env` variable in lib/config.js doesn't always have one the valid values, i.e. 'production', 'staging' or 'cam'.

Actions:
* Recommendation: add a value **whitelist** so the `env` var cannot be invalid; **throw an error** otherwise.

@brian-c , this is based on our discussion in https://github.com/zooniverse/panoptes-javascript-client/pull/22#issuecomment-179524962 and is ready for yor review, arigato.