### PR TITLE
fix broken entry point in package.json, add development strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-module.exports = {
-  apiClient: require('./lib/api-client'),
-  auth: require('./lib/auth'),
-  oauth: require('./lib/oauth'),
-  talkClient: require('./lib/talk-client'),
-  sugar: require('./lib/sugar'),
-  _config: require('./lib/config'),
-};

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,26 +3,31 @@ var DEFAULT_ENV = 'staging';
 var API_HOSTS = {
   production: 'https://www.zooniverse.org',
   staging: 'https://panoptes-staging.zooniverse.org',
+  development: 'https://panoptes-staging.zooniverse.org',
 };
 
 var API_APPLICATION_IDS = {
   production: 'f79cf5ea821bb161d8cbb52d061ab9a2321d7cb169007003af66b43f7b79ce2a',
   staging: '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27',
+  development: '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27',
 };
 
 var OAUTH_HOSTS = {
   production: 'https://panoptes.zooniverse.org',
   staging: 'https://panoptes-staging.zooniverse.org',
+  development: 'https://panoptes-staging.zooniverse.org',
 };
 
 var TALK_HOSTS = {
   production: 'https://talk.zooniverse.org',
   staging: 'https://talk-staging.zooniverse.org',
+  development: 'https://talk-staging.zooniverse.org',
 };
 
 var SUGAR_HOSTS = {
   production: 'https://notifications.zooniverse.org',
   staging: 'https://notifications-staging.zooniverse.org',
+  development: 'https://notifications-staging.zooniverse.org',
 };
 
 var STAT_HOSTS = {
@@ -46,7 +51,7 @@ var envFromShell = process.env.NODE_ENV;
 
 var env = envFromBrowser || envFromShell || DEFAULT_ENV;
 
-if (!env.match(/^(production|staging)$/)) {
+if (!env.match(/^(production|staging|development)$/)) {
   throw new Error('Panoptes Javascript Client Error: Invalid Environment; ' +
     'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".');
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "panoptes-client",
   "version": "2.2.0",
   "description": "A Javascript client to access the Panoptes API",
-  "main": "./lib/client.js",
+  "main": "./lib/api-client.js",
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
We are having trouble consuming panoptes-client npm package because the main in package.json was set to a file that no longer exists. This pull request fixes that, as well as adding strings to make "development" a meaningful environment name in addition to staging.

The npm package will need to be version-bumped after this change is accepted.