### PR TITLE
Increase TOKEN_EXPIRATION_ALLOWANCE to prevent token expiration

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,7 +11,7 @@ var JSON_HEADERS = {
 };
 
 // We don't want to wait until the token is already expired before refreshing it.
-var TOKEN_EXPIRATION_ALLOWANCE = 10 * 1000;
+var TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 
 module.exports = new Model({
   _currentUserPromise: null,

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -13,7 +13,7 @@ var JSON_HEADERS = {
 };
 
 // We don't want to wait until the token is already expired before refreshing it.
-var TOKEN_EXPIRATION_ALLOWANCE = 10 * 1000;
+var TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 
 // Save local storage stuff as something totally obvious
 var LOCAL_STORAGE_PREFIX = 'panoptesClientOAuth_';


### PR DESCRIPTION
This could possibly fix #41.

It appears that tokens are expired momentarily (~20 seconds) before a refresh is issued.  Bumping the refresh request to a minute before expiry could fix this.