### PR TITLE
Tweak stats client for consistency, stub out a test

### DIFF
--- a/lib/stats-client.js
+++ b/lib/stats-client.js
@@ -2,22 +2,20 @@ var config = require('./config');
 var JSONAPIClient = require('json-api-client');
 var makeHTTPRequest = JSONAPIClient.makeHTTPRequest;
 
-statsClient = {
-
+var statsClient = {
   query: function (params) {
-    if (!params.type || !params.period) {
-      return Promise.reject( new Error('Missing required parameter: type and period must be specified.'));
+    if (params.type === undefined || params.period === undefined) {
+      return Promise.reject(new Error('Missing required parameter: type and period must be specified.'));
     }
-    var query = params.workflow_id ? "workflow_id=" + params.workflow_id : "project_id=" + params.project_id;
-    var stats_url = [config.statHost, 'counts', params.type, params.period].join('/') + '?' + query;
-    return makeHTTPRequest('GET', stats_url)
-        .then(
-          function (response) {
-            var results = JSON.parse(response.text);
-            return results["events_over_time"]["buckets"];
-          }
-        )
+
+    var query = params.workflowID ? 'workflow_id=' + params.workflowID : 'project_id=' + params.projectID;
+    var statsURL = [config.statHost, 'counts', params.type, params.period].join('/') + '?' + query;
+
+    return makeHTTPRequest('GET', statsURL).then(function (response) {
+      var results = JSON.parse(response.text);
+      return results['events_over_time']['buckets'];
+    });
   }
-}
+};
 
 module.exports = statsClient;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "browserify index.js --outfile panoptes-client-build.js",
     "lint": "jscs lib test",
     "start-oauth-example": "beefy ./examples/oauth.js",
-    "test": "node test | tap-spec"
+    "test": "node ./test/index.js | tap-spec",
+    "test-stats": "NODE_ENV=production node ./test/stats.js | tap-spec"
   }
 }

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,0 +1,21 @@
+var test = require('blue-tape');
+var statsClient = require('../lib/stats-client');
+
+var GALAXY_ZOO_BARS_ID = '3';
+var GALAXY_ZOO_BARS_WORKFLOW_ID = '1623';
+
+if (process.env.NODE_ENV !== 'production') {
+  console.log('We can currently only tests the stats client in production.');
+  process.exit(1);
+}
+
+test('We can get stats for a project', function(t) {
+  return statsClient.query({
+    project_id: GALAXY_ZOO_BARS_ID,
+    workflow_id: GALAXY_ZOO_BARS_WORKFLOW_ID,
+    type: 'classification',
+    period: 'day'
+  }).then(function(results) {
+    return t.ok(Array.isArray(results));
+  });
+});


### PR DESCRIPTION
Minor updates for more consistent style with the rest of the library. Mainly `workflowID`, not `workflow_id`.

Also stubbed in a dumb test just to see how it works.