### PR TITLE
Auto refresh bearer token

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -5,6 +5,11 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   'Content-Type': 'application/json',
   'Accept': 'application/vnd.api+json; version=1',
 }, {
+  beforeEveryRequest: function() {
+    var auth = require('./auth');
+    return auth.checkBearerToken();
+  },
+
   handleError: function(response) {
     var errorMessage;
     if (response instanceof Error) {

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -4,44 +4,44 @@ var config = require('./config');
 var apiClient = new JSONAPIClient(config.host + '/api', {
   'Content-Type': 'application/json',
   'Accept': 'application/vnd.api+json; version=1',
-});
-
-apiClient.handleError = function(response) {
-  var errorMessage;
-  if (response instanceof Error) {
-    throw response;
-  } else if (typeof response.body === 'object') {
-    if (response.body.error) {
-      errorMessage = response.body.error;
-      if (response.body.error_description) {
-        errorMessage += ' ' + response.error_description;
-      }
-    } else if (Array.isArray(response.body.errors)) {
-      errorMessage = response.body.errors.map(function(error) {
-        if (typeof error.message === 'string') {
-          return error.message;
-        } else if (typeof error.message === 'object') {
-          return Object.keys(error.message).map(function(key) {
-            return key + ' ' + error.message[key];
-          }).join('\n');
+}, {
+  handleError: function(response) {
+    var errorMessage;
+    if (response instanceof Error) {
+      throw response;
+    } else if (typeof response.body === 'object') {
+      if (response.body.error) {
+        errorMessage = response.body.error;
+        if (response.body.error_description) {
+          errorMessage += ' ' + response.error_description;
         }
-      }).join('\n');
+      } else if (Array.isArray(response.body.errors)) {
+        errorMessage = response.body.errors.map(function(error) {
+          if (typeof error.message === 'string') {
+            return error.message;
+          } else if (typeof error.message === 'object') {
+            return Object.keys(error.message).map(function(key) {
+              return key + ' ' + error.message[key];
+            }).join('\n');
+          }
+        }).join('\n');
+      } else {
+        errorMessage = 'Unknown error (bad response body)';
+      }
+    } else if (response.text.indexOf('<!DOCTYPE') !== -1) {
+      // Manually set a reasonable error when we get HTML back (currently 500s will do this).
+      errorMessage = [
+        'There was a problem on the server.',
+        response.req.url,
+        response.status,
+        response.statusText,
+      ].join(' ');
     } else {
-      errorMessage = 'Unknown error (bad response body)';
+      errorMessage = 'Unknown error (bad response)';
     }
-  } else if (response.text.indexOf('<!DOCTYPE') !== -1) {
-    // Manually set a reasonable error when we get HTML back (currently 500s will do this).
-    errorMessage = [
-      'There was a problem on the server.',
-      response.req.url,
-      response.status,
-      response.statusText,
-    ].join(' ');
-  } else {
-    errorMessage = 'Unknown error (bad response)';
-  }
 
-  throw new Error(errorMessage);
-};
+    throw new Error(errorMessage);
+  }
+});
 
 module.exports = apiClient;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,12 +11,14 @@ var JSON_HEADERS = {
 };
 
 // We don't want to wait until the token is already expired before refreshing it.
-var TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
+var BEARER_TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 
 module.exports = new Model({
   _currentUserPromise: null,
+
   _bearerToken: '',
-  _bearerRefreshTimeout: NaN,
+  _bearerTokenExpiration: NaN,
+  _refreshToken: '',
 
   _getAuthToken: function() {
     console.log('Getting auth token');
@@ -66,19 +68,24 @@ module.exports = new Model({
     this._bearerToken = response.access_token;
     apiClient.headers.Authorization = 'Bearer ' + this._bearerToken;
 
-    var refresh = this._refreshBearerToken.bind(this, response.refresh_token);
-    var timeToRefresh = (response.expires_in * 1000) - TOKEN_EXPIRATION_ALLOWANCE;
-    this._bearerRefreshTimeout = setTimeout(refresh, timeToRefresh);
+    this._bearerTokenExpiration = Date.now() + (response.expires_in * 1000);
+    this._refreshToken = response.refresh_token;
 
     return this._bearerToken;
   },
 
-  _refreshBearerToken: function(refreshToken) {
+  _bearerTokenIsExpired: function() {
+    return Date.now() >= this._bearerTokenExpiration - BEARER_TOKEN_EXPIRATION_ALLOWANCE;
+  },
+
+  _refreshBearerToken: function() {
+    console.log('Refreshing expired bearer token');
+
     var url = config.host + '/oauth/token';
 
     var data = {
       grant_type: 'refresh_token',
-      refresh_token: refreshToken,
+      refresh_token: this._refreshToken,
       client_id: config.clientAppID,
     };
 
@@ -96,7 +103,8 @@ module.exports = new Model({
   _deleteBearerToken: function() {
     this._bearerToken = '';
     delete apiClient.headers.Authorization;
-    clearTimeout(this._bearerRefreshTimeout);
+    this._bearerTokenExpiration = NaN;
+    this._refreshToken = '';
     console.log('Deleted bearer token');
   },
 
@@ -182,6 +190,16 @@ module.exports = new Model({
     }
 
     return this._currentUserPromise;
+  },
+
+  checkBearerToken: function() {
+    var awaitBearerToken;
+    if (this._bearerTokenIsExpired()) {
+      awaitBearerToken = this._refreshBearerToken();
+    } else {
+      awaitBearerToken = Promise.resolve(this._bearerToken);
+    }
+    return awaitBearerToken;
   },
 
   signIn: function(credentials) {


### PR DESCRIPTION
Depends on zooniverse/json-api-client#30.

Instead of using `setTimeout` to fetch a new bearer token before the current one expires, this gives the auth module a `checkBearerToken` method (which will refresh if needed) and calls if `beforeEveryRequest` on the API client.

We also talked about refreshing the token and remaking requests when we get a 401, which I thought would require a major rewrite, but now that I think about it again it might not be a big deal. Any strong preference for me to look into it more?

(The `handleError` method is just moved, add `&w=1` to the PR URL to ignore it.)