### PR TITLE
Auth module does auth wth the normal host

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -41,7 +41,7 @@ module.exports = new Model({
       console.info('Already had a bearer token', this._bearerToken);
       return Promise.resolve(this._bearerToken);
     } else {
-      var url = config.oauthHost + '/oauth/token';
+      var url = config.host + '/oauth/token';
 
       var data = {
         'grant_type': 'password',


### PR DESCRIPTION
Not sure what the rules are for hitting /oauth/token from www.zooniverse.org vs. panoptes.zooniverse.org. Should I switch this in the oauth module too?