### PR TITLE
Only make one token refresh request

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -19,6 +19,7 @@ module.exports = new Model({
   _bearerToken: '',
   _bearerTokenExpiration: NaN,
   _refreshToken: '',
+  _tokenRefreshPromise: null,
 
   _getAuthToken: function() {
     console.log('Getting auth token');
@@ -79,25 +80,32 @@ module.exports = new Model({
   },
 
   _refreshBearerToken: function() {
-    console.log('Refreshing expired bearer token');
+    if (this._tokenRefreshPromise === null) {
+      console.log('Refreshing expired bearer token');
 
-    var url = config.host + '/oauth/token';
+      var url = config.host + '/oauth/token';
 
-    var data = {
-      grant_type: 'refresh_token',
-      refresh_token: this._refreshToken,
-      client_id: config.clientAppID,
-    };
+      var data = {
+        grant_type: 'refresh_token',
+        refresh_token: this._refreshToken,
+        client_id: config.clientAppID,
+      };
 
-    return makeHTTPRequest('POST', url, data, JSON_HEADERS)
-      .then(function(request) {
-        var token = this._handleNewBearerToken(request);
-        console.info('Refreshed bearer token', token.slice(-6));
-      }.bind(this))
-      .catch(function(request) {
-        console.error('Failed to refresh bearer token');
-        apiClient.handleError(request);
-      });
+      this._tokenRefreshPromise = makeHTTPRequest('POST', url, data, JSON_HEADERS)
+        .then(function(request) {
+          var token = this._handleNewBearerToken(request);
+          console.info('Refreshed bearer token', token.slice(-6));
+        }.bind(this))
+        .catch(function(request) {
+          console.error('Failed to refresh bearer token');
+          apiClient.handleError(request);
+        })
+        .then(function() {
+          this._tokenRefreshPromise = null;
+        }.bind(this));
+    }
+
+    return this._tokenRefreshPromise;
   },
 
   _deleteBearerToken: function() {


### PR DESCRIPTION
Cache the promise for the token refresh request so that multiple aren't made at the same time.

(Changes are mostly whitespace.)