### PR TITLE
simplify handleError with new error object

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -10,42 +10,12 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
     return auth.checkBearerToken();
   },
 
-  handleError: function(response) {
-    var errorMessage;
-    if (response instanceof Error) {
-      throw response;
-    } else if (typeof response.body === 'object') {
-      if (response.body.error) {
-        errorMessage = response.body.error;
-        if (response.body.error_description) {
-          errorMessage += ' ' + response.error_description;
-        }
-      } else if (Array.isArray(response.body.errors)) {
-        errorMessage = response.body.errors.map(function(error) {
-          if (typeof error.message === 'string') {
-            return error.message;
-          } else if (typeof error.message === 'object') {
-            return Object.keys(error.message).map(function(key) {
-              return key + ' ' + error.message[key];
-            }).join('\n');
-          }
-        }).join('\n');
-      } else {
-        errorMessage = 'Unknown error (bad response body)';
-      }
-    } else if (response.text.indexOf('<!DOCTYPE') !== -1) {
-      // Manually set a reasonable error when we get HTML back (currently 500s will do this).
-      errorMessage = [
-        'There was a problem on the server.',
-        response.req.url,
-        response.status,
-        response.statusText,
-      ].join(' ');
-    } else {
-      errorMessage = 'Unknown error (bad response)';
+  handleError: function(error) {
+    if (error instanceof Error)
+      throw error;
+    else {
+      throw new Error('Unknown error (bad response)');
     }
-
-    throw new Error(errorMessage);
   }
 });
 


### PR DESCRIPTION
see [`json-api-client` Issue 36](https://github.com/zooniverse/json-api-client/issues/36)
conditional to [`json-api-client` PR 37](https://github.com/zooniverse/json-api-client/pull/37)

this is a simple refactor that utilizes the potential error object received from `json-api-client`.