### PR TITLE
Add HTTP status to errors

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -45,7 +45,10 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
       errorMessage = 'Unknown error (bad response)';
     }
 
-    throw new Error(errorMessage);
+    let e = new Error(errorMessage);
+    e.status = response.status;
+    e.statusText = response.statusText;
+    throw e;
   }
 });
 


### PR DESCRIPTION
Alternative to #62 

This keeps the old error message generator, for backward compatibility, but adds the HTTP status code and text to the returned error.