### PR TITLE
Add http_cache=true to all requests

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -5,6 +5,10 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   'Content-Type': 'application/json',
   'Accept': 'application/vnd.api+json; version=1',
 }, {
+  params: {
+    http_cache: true
+  },
+
   beforeEveryRequest: function() {
     var auth = require('./auth');
     return auth.checkBearerToken();

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -5,9 +5,7 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   'Content-Type': 'application/json',
   'Accept': 'application/vnd.api+json; version=1',
 }, {
-  params: {
-    http_cache: true
-  },
+  params: config.params,
 
   beforeEveryRequest: function() {
     var auth = require('./auth');

--- a/lib/config.js
+++ b/lib/config.js
@@ -64,7 +64,11 @@ var query = window.location.search.substring(1);
 query = query.split('&');
 query.map(function(param) {
   var pair = param.split('=');
-  defaultParams[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+  var key = decodeURIComponent(pair[0]);
+  var value = decodeURIComponent(pair[1]);
+  if (defaultParams[key]) {
+    defaultParams[key] = value;
+  }
 });
 
 module.exports = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,17 @@ if (!env.match(/^(production|staging|development)$/)) {
     'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".');
 }
 
+var defaultParams = {
+  http_cache: true
+}
+
+var query = window.location.search.substring(1);
+query = query.split('&');
+query.map(function(param) {
+  var pair = param.split('=');
+  defaultParams[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+});
+
 module.exports = {
   host: hostFromBrowser || hostFromShell || API_HOSTS[env],
   clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env],
@@ -63,6 +74,7 @@ module.exports = {
   sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
   statHost: statFromBrowser || statFromShell || STAT_HOSTS[env],
   oauthHost: OAUTH_HOSTS[env],
+  params: defaultParams
 };
 
 // Try and match the location.search property against a regex. Basically mimics

--- a/lib/talk-client.js
+++ b/lib/talk-client.js
@@ -7,6 +7,7 @@ var talkClient = new JSONAPIClient(config.talkHost, {
   'Accept': 'application/json',
 });
 
+talkClient.params = apiClient.params;
 talkClient.headers = apiClient.headers;
 talkClient.handleError = apiClient.handleError;
 


### PR DESCRIPTION
Should enable the client to make use of HTTP caching in the Panoptes API, for SGL.