### PR TITLE
Check for response.body for 500 errors

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -17,7 +17,7 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
     if (response instanceof Error) {
       throw response;
     } else if (typeof response.body === 'object') {
-      if (response.body.error) {
+      if (response.body && response.body.error) {
         errorMessage = response.body.error;
         if (response.body.error_description) {
           errorMessage += ' ' + response.error_description;

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
   "devDependencies": {
     "beefy": "^2.1.6",
     "blue-tape": "~0.1.11",
-    "browserify": "^12.0.1",
     "jscs": "^2.7.0",
     "tap-spec": "~4.1.1"
   },
   "scripts": {
-    "build": "browserify index.js --outfile panoptes-client-build.js",
     "lint": "jscs lib test",
     "start-oauth-example": "beefy ./examples/oauth.js",
     "test": "node ./test/index.js | tap-spec",


### PR DESCRIPTION
When using `typeof` on `null` it returns as an object. With the 500 error, the response body is null. Right now, that means that there will be a type error on line 20 since we're not checking for the existence of the response body. 

This also leads the question of how we should be handling 500 errors and if the client should be doing something differently. This PR will at least fix the type error.  