### PR TITLE
Fix all type errors related to null response body for 500 errors

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -16,13 +16,13 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
     var errorMessage;
     if (response instanceof Error) {
       throw response;
-    } else if (typeof response.body === 'object') {
+    } else if (response.body && typeof response.body === 'object') {
       if (response.body && response.body.error) {
         errorMessage = response.body.error;
         if (response.body.error_description) {
           errorMessage += ' ' + response.error_description;
         }
-      } else if (Array.isArray(response.body.errors)) {
+      } else if (response.body && Array.isArray(response.body.errors)) {
         errorMessage = response.body.errors.map(function(error) {
           if (typeof error.message === 'string') {
             return error.message;
@@ -35,7 +35,7 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
       } else {
         errorMessage = 'Unknown error (bad response body)';
       }
-    } else if (response.text.indexOf('<!DOCTYPE') !== -1) {
+    } else if (response.text.indexOf('<!DOCTYPE') !== -1 || response.status === 500) {
       // Manually set a reasonable error when we get HTML back (currently 500s will do this).
       errorMessage = [
         'There was a problem on the server.',


### PR DESCRIPTION
Follow up to #65. I didn't fully think that through and so there was another line that was throwing a type error when the response body is null. I've added explicit checks for `response.body` as well as added an or statement for `response.status === 500` so that a useful error is built. 