### PR TITLE
json-api-client 3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "dependencies": {
-    "json-api-client": "~3.2.0",
+    "json-api-client": "~3.3.0",
     "sugar-client": "^1.0.1",
     "local-storage": "^1.4.2"
   },


### PR DESCRIPTION
Updates json-api-client to accept query params on POST and PUT requests.

Required for zooniverse/pandora#46