### PR TITLE
Check the bearer token before talk client requests

### DIFF
--- a/lib/talk-client.js
+++ b/lib/talk-client.js
@@ -10,5 +10,6 @@ var talkClient = new JSONAPIClient(config.talkHost, {
 talkClient.params = apiClient.params;
 talkClient.headers = apiClient.headers;
 talkClient.handleError = apiClient.handleError;
+talkClient.beforeEveryRequest = apiClient.beforeEveryRequest;
 
 module.exports = talkClient;


### PR DESCRIPTION
Share the `beforeEveryRequest` method between the API client and the Talk client.

Fixes zooniverse/Panoptes-Front-End#4179