### PR TITLE
Persist bearer token details across page reloads

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -65,9 +65,9 @@ module.exports = new Model({
       this._clientAppId = appID;
 
       // Handle new token details if we've completed a sign in
-      if (checkUrlForToken(window.location.href)) {
+      if (checkUrlForToken(window.location.hash)) {
         console.log('Token found in URL');
-        var tokenDetails = parseUrl(window.location.href);
+        var tokenDetails = parseUrl(window.location.hash);
         this._handleBearerToken(tokenDetails);
         SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
 
@@ -273,11 +273,13 @@ function checkUrlForToken(string) {
 }
 
 function parseUrl(string) {
-  return {
-    access_token: string.match(/access_token=([\w\-\.]+)/)[1],
-    token_type: string.match(/token_type=(\w+)/)[1],
-    expires_in: string.match(/expires_in=(\d+)/)[1],
-  };
+  var params = string.slice(1).split('&');
+  var tokenDetails = {};
+  params.forEach(function(param) {
+    var [key, value] = param.split('=');
+    tokenDetails[key] = value;
+  });
+  return tokenDetails;
 }
 
 function isTokenStillValid(tokenDetails) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -18,6 +18,9 @@ var TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 // Save local storage stuff as something totally obvious
 var LOCAL_STORAGE_PREFIX = 'panoptesClientOAuth_';
 
+// Specify whether to use local or session storage for session data.
+var SESSION_STORAGE = window.sessionStorage;
+
 // Create our model, then do stuff with it later
 module.exports = new Model({
   _bearerRefreshTimeout: NaN,
@@ -66,7 +69,7 @@ module.exports = new Model({
         console.log('Token found in URL');
         var tokenDetails = parseUrl(window.location.href);
         this._handleBearerToken(tokenDetails);
-        sessionStorage.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
+        SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
 
         // And redirect to the desired page
         var url = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
@@ -153,7 +156,7 @@ module.exports = new Model({
   },
 
   _checkForPanoptesSession: function() {
-    var sessionTokenDetails = JSON.parse(sessionStorage.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
+    var sessionTokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
     var redirectUri = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
     this.update({
       _currentSessionCheckPromise: new Promise(function(resolve, reject) {
@@ -202,7 +205,7 @@ module.exports = new Model({
     console.log('Deleting bearer token');
     this._tokenDetails = null;
     delete apiClient.headers.Authorization;
-    sessionStorage.removeItem(LOCAL_STORAGE_PREFIX + 'tokenDetails');
+    SESSION_STORAGE.removeItem(LOCAL_STORAGE_PREFIX + 'tokenDetails');
   },
 
   _getAuthToken: function() {
@@ -248,7 +251,7 @@ module.exports = new Model({
   _refreshBearerToken: function() {
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
-        sessionStorage.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
+        SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
         return this._handleBearerToken(tokenDetails);
       }.bind(this))
       .catch(function (error) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -249,6 +249,7 @@ module.exports = new Model({
   },
 
   _refreshBearerToken: function() {
+    this._deleteBearerToken();
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
         SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -66,6 +66,7 @@ module.exports = new Model({
         console.log('Token found in URL');
         var tokenDetails = parseUrl(window.location.href);
         this._handleBearerToken(tokenDetails);
+        sessionStorage.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
 
         // And redirect to the desired page
         var url = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
@@ -152,9 +153,14 @@ module.exports = new Model({
   },
 
   _checkForPanoptesSession: function() {
+    var sessionTokenDetails = JSON.parse(sessionStorage.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
     var redirectUri = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
     this.update({
       _currentSessionCheckPromise: new Promise(function(resolve, reject) {
+        if (sessionTokenDetails) {
+          resolve(sessionTokenDetails);
+        }
+
         if (!redirectUri) {
           reject(Error('No redirect URI found'));
         }
@@ -196,7 +202,7 @@ module.exports = new Model({
     console.log('Deleting bearer token');
     this._tokenDetails = null;
     delete apiClient.headers.Authorization;
-    ls.remove(LOCAL_STORAGE_PREFIX + 'tokenDetails');
+    sessionStorage.removeItem(LOCAL_STORAGE_PREFIX + 'tokenDetails');
   },
 
   _getAuthToken: function() {
@@ -242,6 +248,7 @@ module.exports = new Model({
   _refreshBearerToken: function() {
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
+        sessionStorage.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
         return this._handleBearerToken(tokenDetails);
       }.bind(this))
       .catch(function (error) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -257,6 +257,7 @@ module.exports = new Model({
       }.bind(this))
       .catch(function (error) {
         console.info('Panoptes session has expired');
+        console.log(error);
       });
   },
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -185,7 +185,7 @@ module.exports = new Model({
             }
           } catch (error) {
             if (error.name === 'SecurityError') {
-              error = new Error('No existing Panoptes session found');
+              console.warn('No existing Panoptes session found');
             }
             reject(error);
           } finally {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Use window session storage to store the current bearer token across page reloads, in case 3rd party cookies are blocked.

I think this will fix #72, where sign-in does not work on sites like antislaverymanuscripts.org if 3rd party cookies are disabled.

It does not fix token refreshes, for long sessions, being blocked in that case.