### PR TITLE
Remove array destructuring from parseUrl()

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -277,9 +277,9 @@ function checkUrlForToken(string) {
 function parseUrl(string) {
   var params = string.slice(1).split('&');
   var tokenDetails = {};
-  params.forEach(function(param) {
-    var [key, value] = param.split('=');
-    tokenDetails[key] = value;
+  params.forEach(function(paramString) {
+    var param = paramString.split('=');
+    tokenDetails[param[0]] = param[1];
   });
   return tokenDetails;
 }


### PR DESCRIPTION
Array destructuring isn't supported in IE, so remove it.