### PR TITLE
Add checkBearerToken() to OAuth

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -29,6 +29,17 @@ module.exports = new Model({
   _currentUserPromise: null,
   _tokenDetails: null,
 
+  checkBearerToken: function() {
+    var awaitBearerToken;
+    if (this._bearerTokenIsExpired()) {
+      awaitBearerToken = this._refreshBearerToken();
+    } else {
+      var tokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
+      awaitBearerToken = Promise.resolve(tokenDetails);
+    }
+    return awaitBearerToken;
+  },
+
   checkCurrent: function() {
     console.log('Checking current user');
 
@@ -152,6 +163,15 @@ module.exports = new Model({
       '&redirect_uri=',
       redirectUri
     ].join('');
+  },
+
+  _bearerTokenIsExpired: function() {
+    var tokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
+    if (tokenDetails) {
+      return Date.now() >= tokenDetails.expires_at - TOKEN_EXPIRATION_ALLOWANCE;
+    } else {
+      return false;
+    }
   },
 
   _checkForPanoptesSession: function() {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -13,7 +13,7 @@ var JSON_HEADERS = {
 };
 
 // We don't want to wait until the token is already expired before refreshing it.
-var TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
+var TOKEN_EXPIRATION_ALLOWANCE = 5 * 60 * 1000;
 
 // Save local storage stuff as something totally obvious
 var LOCAL_STORAGE_PREFIX = 'panoptesClientOAuth_';

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -304,10 +304,6 @@ function parseUrl(string) {
   return tokenDetails;
 }
 
-function isTokenStillValid(tokenDetails) {
-  return (tokenDetails.started_at + tokenDetails.expires_in) > Date.now();
-}
-
 function createIFrame(url) {
   var iframe = document.createElement('iframe');
   iframe.setAttribute('src', url);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -69,7 +69,6 @@ module.exports = new Model({
         console.log('Token found in URL');
         var tokenDetails = parseUrl(window.location.hash);
         this._handleNewBearerToken(tokenDetails);
-        SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
 
         // And redirect to the desired page
         var url = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
@@ -245,6 +244,8 @@ module.exports = new Model({
     var refresh = this._refreshBearerToken.bind(this);
     var timeToRefresh = (tokenDetails.expires_in * 1000) - TOKEN_EXPIRATION_ALLOWANCE;
     this._bearerRefreshTimeout = setTimeout(refresh, timeToRefresh);
+    tokenDetails.expires_at = Date.now() + (tokenDetails.expires_in * 1000);
+    SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
     return tokenDetails;
   },
 
@@ -252,7 +253,6 @@ module.exports = new Model({
     this._deleteBearerToken();
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
-        SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
         return this._handleNewBearerToken(tokenDetails);
       }.bind(this))
       .catch(function (error) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -68,7 +68,7 @@ module.exports = new Model({
       if (checkUrlForToken(window.location.hash)) {
         console.log('Token found in URL');
         var tokenDetails = parseUrl(window.location.hash);
-        this._handleBearerToken(tokenDetails);
+        this._handleNewBearerToken(tokenDetails);
         SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
 
         // And redirect to the desired page
@@ -79,7 +79,7 @@ module.exports = new Model({
       // If not, let's try and pick up an existing Panoptes session anyway
       this._checkForPanoptesSession()
         .then(function(tokenDetails) {
-          this._handleBearerToken(tokenDetails);
+          this._handleNewBearerToken(tokenDetails);
           resolve(tokenDetails)
         }.bind(this))
         .catch(function (error) {
@@ -237,7 +237,7 @@ module.exports = new Model({
       });
   },
 
-  _handleBearerToken: function(tokenDetails) {
+  _handleNewBearerToken: function(tokenDetails) {
     console.log('Got new bearer token', tokenDetails.access_token.slice(-6));
     this._tokenDetails = tokenDetails;
     apiClient.headers.Authorization = 'Bearer ' + tokenDetails.access_token;
@@ -253,7 +253,7 @@ module.exports = new Model({
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
         SESSION_STORAGE.setItem(LOCAL_STORAGE_PREFIX + 'tokenDetails', JSON.stringify(tokenDetails));
-        return this._handleBearerToken(tokenDetails);
+        return this._handleNewBearerToken(tokenDetails);
       }.bind(this))
       .catch(function (error) {
         console.info('Panoptes session has expired');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Towards #76 

Stores an `expires_at` timestamp with new tokens. Adds a `checkBearerToken` method that can be used by client apps to check the token, and refresh it if possible.

Tries, as far as possible, to copy the equivalent methods in the [Auth](/zooniverse/panoptes-javascript-client/tree/master/lib/auth.js) module.

```javascript
oauth.checkBearerToken()
.then(function (token) {
  // I'm probably still logged in
})
.catch(function (error) {
  // refreshing the token failed
}
```