### PR TITLE
OAuth improvements

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -87,11 +87,7 @@ module.exports = new Model({
       }
 
       // If not, let's try and pick up an existing Panoptes session anyway
-      this._checkForPanoptesSession()
-        .then(function(tokenDetails) {
-          this._handleNewBearerToken(tokenDetails);
-          resolve(tokenDetails)
-        }.bind(this))
+      this.checkBearerToken()
         .catch(function (error) {
           // We probably haven't signed in before
           console.info(error);
@@ -270,7 +266,6 @@ module.exports = new Model({
   },
 
   _refreshBearerToken: function() {
-    this._deleteBearerToken();
     return this._checkForPanoptesSession()
       .then(function(tokenDetails) {
         return this._handleNewBearerToken(tokenDetails);
@@ -278,6 +273,8 @@ module.exports = new Model({
       .catch(function (error) {
         console.info('Panoptes session has expired');
         console.log(error);
+        this._deleteBearerToken();
+        return null;
       });
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
- Don't clear the saved token before a refresh. We might need to use it before we receive the new token.
- Return null from the refresh if we can't obtain a token.
- Call `checkBearerToken()` on initial load, if no token is present in the URL.