### PR TITLE
Replace _checkPanoptesSession with _getNewToken

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -277,7 +277,7 @@ module.exports = new Model({
         console.log(error);
         this._deleteBearerToken();
         return null;
-      });
+      }.bind(this));
   },
 
   _saveRedirectUri: function(redirectUri) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -174,14 +174,10 @@ module.exports = new Model({
     }
   },
 
-  _checkForPanoptesSession: function() {
-    var sessionTokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
+  _getNewToken: function() {
     var redirectUri = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
     this.update({
       _currentSessionCheckPromise: new Promise(function(resolve, reject) {
-        if (sessionTokenDetails) {
-          resolve(sessionTokenDetails);
-        }
 
         if (!redirectUri) {
           reject(Error('No redirect URI found'));
@@ -272,7 +268,7 @@ module.exports = new Model({
   },
 
   _refreshBearerToken: function() {
-    return this._checkForPanoptesSession()
+    return this._getNewToken()
       .then(function(tokenDetails) {
         return this._handleNewBearerToken(tokenDetails);
       }.bind(this))

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -31,7 +31,7 @@ module.exports = new Model({
 
   checkBearerToken: function() {
     var awaitBearerToken;
-    if (this._bearerTokenIsExpired()) {
+    if (this._bearerTokenWillExpire()) {
       awaitBearerToken = this._refreshBearerToken();
     } else {
       var tokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
@@ -165,7 +165,7 @@ module.exports = new Model({
     ].join('');
   },
 
-  _bearerTokenIsExpired: function() {
+  _bearerTokenWillExpire: function() {
     var tokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
     if (tokenDetails) {
       return Date.now() >= tokenDetails.expires_at - TOKEN_EXPIRATION_ALLOWANCE;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -252,6 +252,18 @@ module.exports = new Model({
       });
   },
 
+  _handleExpiredToken: function() {
+    var tokenDetails = JSON.parse(SESSION_STORAGE.getItem(LOCAL_STORAGE_PREFIX + 'tokenDetails'));
+    var tokenHasExpired = false;
+    if (tokenDetails && tokenDetails.expires_at) {
+      tokenHasExpired = Date.now() > tokenDetails.expires_at;
+    }
+    if (tokenHasExpired) {
+      console.info('Panoptes session has expired');
+      this._deleteBearerToken();
+    }
+  },
+
   _handleNewBearerToken: function(tokenDetails) {
     if (tokenDetails && tokenDetails.access_token) {
       console.log('Got new bearer token', tokenDetails.access_token.slice(-6));
@@ -273,9 +285,8 @@ module.exports = new Model({
         return this._handleNewBearerToken(tokenDetails);
       }.bind(this))
       .catch(function (error) {
-        console.info('Panoptes session has expired');
         console.log(error);
-        this._deleteBearerToken();
+        this._handleExpiredToken();
         return null;
       }.bind(this));
   },


### PR DESCRIPTION
Replaces `_checkPanoptesSession()` with `_getNewToken()`, which attempts to get a new token from Panoptes via an iframe (and should do only that.) Stored tokens are not returned, since we should only be calling this method when the stored token is about to expire.

Fixes a problem mentioned in https://github.com/zooniverse/shakespeares_world/issues/366#issuecomment-362587573 which is that the client would always return an expired token, if it was stored in session storage.

Also fixes a bug where `checkBearerToken` throws an error when getting a new token, because `this._deleteBearerToken` is undefined in the catch block here https://github.com/zooniverse/panoptes-javascript-client/blob/595e694c71dd877ddbae4a13e670fc466314258e/lib/oauth.js#L279-L284