### PR TITLE
2.9.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [v2.9.5](https://github.com/zooniverse/panoptes-javascript-client/tree/v2.9.5) (2018-03-06)
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v2.9.4...v2.9.5)
+
+**Closed issues:**
+
+- `\_handleNewBearerToken\(\)` florps on `.slice\(\)` [\#84](https://github.com/zooniverse/panoptes-javascript-client/issues/84)
+
+**Merged pull requests:**
+
+- Replace \_checkPanoptesSession with \_getNewToken [\#86](https://github.com/zooniverse/panoptes-javascript-client/pull/86) ([eatyourgreens](https://github.com/eatyourgreens))
+
+
 ## [v2.9.4](https://github.com/zooniverse/panoptes-javascript-client/tree/v2.9.4) (2018-02-27)
 [Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v2.9.3...v2.9.4)
 
@@ -12,6 +24,7 @@
 
 **Merged pull requests:**
 
+- Massive changelog update [\#83](https://github.com/zooniverse/panoptes-javascript-client/pull/83) ([eatyourgreens](https://github.com/eatyourgreens))
 - OAuth improvements [\#82](https://github.com/zooniverse/panoptes-javascript-client/pull/82) ([eatyourgreens](https://github.com/eatyourgreens))
 
 ## [v2.9.2](https://github.com/zooniverse/panoptes-javascript-client/tree/v2.9.2) (2018-02-13)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Fixes `this._deleteBearerToken` error on refresh (#84)

Token refresh won't return an expired token if automatic refresh fails (#86).