### PR TITLE
Use local storage for session tokens

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -19,7 +19,7 @@ var TOKEN_EXPIRATION_ALLOWANCE = 5 * 60 * 1000;
 var LOCAL_STORAGE_PREFIX = 'panoptesClientOAuth_';
 
 // Specify whether to use local or session storage for session data.
-var SESSION_STORAGE = window.sessionStorage;
+var SESSION_STORAGE = window.localStorage;
 
 // Create our model, then do stuff with it later
 module.exports = new Model({


### PR DESCRIPTION
Fixes #90 by persisting your auth token across browser tabs and sessions.

My naming was not great here. SESSION_STORAGE refers to your login session, not the browser session.