### PR TITLE
Optional redirect

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -75,7 +75,8 @@ module.exports = new Model({
       console.info('Setting app ID to', appID);
       ls.get(LOCAL_STORAGE_PREFIX + 'clientAppId', appID);
       this._clientAppId = appID;
-      if (options.customRedirects) this._customRedirects = options.customRedirects;
+      var initializationOptions = options || {};
+      if (initializationOptions.customRedirects) this._customRedirects = initializationOptions.customRedirects;
 
       // Handle new token details if we've completed a sign in
       if (checkUrlForToken(window.location.hash)) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -75,6 +75,7 @@ module.exports = new Model({
       console.info('Setting app ID to', appID);
       ls.get(LOCAL_STORAGE_PREFIX + 'clientAppId', appID);
       this._clientAppId = appID;
+      if (options.customRedirects) this._customRedirects = options.customRedirects;
 
       // Handle new token details if we've completed a sign in
       if (checkUrlForToken(window.location.hash)) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -28,6 +28,7 @@ module.exports = new Model({
   _currentSessionCheckPromise: null,
   _currentUserPromise: null,
   _tokenDetails: null,
+  _customRedirects: false,
 
   checkBearerToken: function() {
     var awaitBearerToken;
@@ -62,7 +63,7 @@ module.exports = new Model({
     return this._currentUserPromise;
   },
 
-  init: function (appID) {
+  init: function (appID, options) {
     return new Promise(function(resolve, reject) {
 
       // Don't init if we're in an iFrame, as we could be the token refresh process
@@ -81,9 +82,11 @@ module.exports = new Model({
         var tokenDetails = tokenFromLocation(window.location);
         this._handleNewBearerToken(tokenDetails);
 
-        // And redirect to the desired page
-        var url = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
-        location.assign(url);
+        if (!this._customRedirects) {
+          // And redirect to the desired page
+          var url = ls.get(LOCAL_STORAGE_PREFIX + 'redirectUri');
+          location.assign(url);
+        }
       }
 
       // If not, let's try and pick up an existing Panoptes session anyway


### PR DESCRIPTION
This makes the redirects built into the oauth client optional. The fixes put into place for ASM fixed [an old bug](https://github.com/zooniverse/panoptes-javascript-client/pull/75/files#r164709450) that the custom redirect behavior in Zooniverse Classrooms relied upon. We still want this custom redirect behavior for the classroom join page. This adds an options object to the `init` call where we can set this. When `true`, the `location.assign` call in the initialization will not be called. 

There aren't any tests written for the oauth client, so we'll have to do some manual testing 🤷‍♀️ I'll open a parallel PR on edu-api-front-end.