### PR TITLE
Return an error for empty response body

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -16,8 +16,8 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
     var errorMessage;
     if (response instanceof Error) {
       throw response;
-    } else if (typeof response.body === 'object') {
-      if (response.body && response.body.error) {
+    } else if (response.body && typeof response.body === 'object') {
+      if (response.body.error) {
         errorMessage = response.body.error;
         if (response.body.error_description) {
           errorMessage += ' ' + response.error_description;
@@ -35,14 +35,6 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
       } else {
         errorMessage = 'Unknown error (bad response body)';
       }
-    } else if (response.text.indexOf('<!DOCTYPE') !== -1) {
-      // Manually set a reasonable error when we get HTML back (currently 500s will do this).
-      errorMessage = [
-        'There was a problem on the server.',
-        response.req.url,
-        response.status,
-        response.statusText,
-      ].join(' ');
     } else {
       errorMessage = 'Unknown error (bad response)';
     }


### PR DESCRIPTION
Check for response.body before checking for response.body.error or response.body.errors.
Don't sniff the response for <DOCTYPE.
Report 'unknown error' with status and status text if the response body is empty.

Fixes a bug where the client crashes on 500 errors, because `response.body` is null.

Closes #99.
