### PR TITLE
Doorkeeper 4.4.1 compatibility

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -307,7 +307,7 @@ module.exports = new Model({
 *******************************************/
 function checkUrlForToken(string) {
   return string.indexOf('access_token') !== -1 &&
-    string.indexOf('token_type=bearer') !== -1;
+    /token_type=(B|b)earer/.test(string);
 }
 
 function tokenFromLocation(loc) {


### PR DESCRIPTION
## PR Overview
The `doorkeeper` dependency in Panoptes has been bumped up to 4.4.1, which changes the bearer token to the **Bearer** token (capital B). This change means that users of Custom Front End projects won't be able to sign in, as the panoptes-client won't recognise the (lower-case) bearer token being passed back to the app.

This PR fixes the issue by changing the check to accept either `token_type=Bearer` or `token_type=bearer`.

### Status
Ready for review, and more thorough testing needed; I'm not sure if I'm missing anything beyond the sign-in problems on localhost that I'm experiencing.