### PR TITLE
Update stats-client for user_id query

### DIFF
--- a/lib/stats-client.js
+++ b/lib/stats-client.js
@@ -8,10 +8,20 @@ var statsClient = {
       return Promise.reject(new Error('Missing required parameter: type and period must be specified.'));
     }
 
-    var query = params.workflowID ? 'workflow_id=' + params.workflowID : 'project_id=' + params.projectID;
-    var statsURL = [config.statHost, 'counts', params.type, params.period].join('/') + '?' + query;
+    var data = {};
+    if (params.workflowID) {
+      data['workflow_id'] = params.workflowID;
+    }
+    if (params.projectID) {
+      data['project_id'] = params.projectID;
+    }
+    if (params.userID) {
+      data['user_id'] = params.userID;
+    }
+    
+    var statsURL = [config.statHost, 'counts', params.type, params.period].join('/');
 
-    return makeHTTPRequest('GET', statsURL).then(function (response) {
+    return makeHTTPRequest('GET', statsURL, data).then(function (response) {
       var results = JSON.parse(response.text);
       return results['events_over_time']['buckets'];
     });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "tap-spec": "^5.0.0"
   },
   "scripts": {
-    "test": "node ./test/index.js | tap-spec",
-    "test-stats": "NODE_ENV=production node ./test/stats.js | tap-spec"
+    "test": "node ./test/index.js | tap-spec"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,2 @@
 require('./auth');
+require('./stats');

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,22 +1,46 @@
 var test = require('blue-tape');
 var statsClient = require('../lib/stats-client');
 
-var GALAXY_ZOO_BARS_ID = '3';
-var GALAXY_ZOO_BARS_WORKFLOW_ID = '1623';
-var USER_ID = '1459668'; // user "zootester1" on production
-
-if (process.env.NODE_ENV !== 'production') {
-  console.log('We can currently only tests the stats client in production.');
-  process.exit(1);
-}
+var PROJECT_ID = '335'; // staging project "I Fancy Cats" ID = 335, production project "Galaxy Zoo: Bar Lengths" ID = 3
+var WORKFLOW_ID = '693'; // staging workflow "I Fancy Cats - Cat me!" ID = 693, production workflow "Galaxy Zoo: Bar Lengths - Find Off-Center Bars" ID = 1623
+var USER_ID = '1325801'; // staging "zootester1" ID = 1325801, production "zootester1" ID = 1459668
 
 test('We can get stats for a project', function(t) {
   return statsClient.query({
     period: 'day',
-    projectID: GALAXY_ZOO_BARS_ID,
+    projectID: PROJECT_ID,
+    type: 'classification'
+  }).then(function(results) {
+    return t.ok(Array.isArray(results), 'Should get an array back');
+  });
+});
+
+test('We can get stats for a workflow', function(t) {
+  return statsClient.query({
+    period: 'day',
     type: 'classification',
-    userID: USER_ID,
-    workflowID: GALAXY_ZOO_BARS_WORKFLOW_ID
+    workflowID: WORKFLOW_ID
+  }).then(function(results) {
+    return t.ok(Array.isArray(results), 'Should get an array back');
+  });
+});
+
+test('We can get stats for a user', function(t) {
+  return statsClient.query({
+    period: 'day',
+    type: 'classification',
+    userID: USER_ID
+  }).then(function(results) {
+    return t.ok(Array.isArray(results), 'Should get an array back');
+  });
+});
+
+test('We can get stats for a user by project', function(t) {
+  return statsClient.query({
+    period: 'day',
+    projectID: PROJECT_ID,
+    type: 'classification',
+    userID: USER_ID
   }).then(function(results) {
     return t.ok(Array.isArray(results), 'Should get an array back');
   });

--- a/test/stats.js
+++ b/test/stats.js
@@ -3,6 +3,7 @@ var statsClient = require('../lib/stats-client');
 
 var GALAXY_ZOO_BARS_ID = '3';
 var GALAXY_ZOO_BARS_WORKFLOW_ID = '1623';
+var USER_ID = '1459668'; // user "zootester1" on production
 
 if (process.env.NODE_ENV !== 'production') {
   console.log('We can currently only tests the stats client in production.');
@@ -11,10 +12,11 @@ if (process.env.NODE_ENV !== 'production') {
 
 test('We can get stats for a project', function(t) {
   return statsClient.query({
+    period: 'day',
     projectID: GALAXY_ZOO_BARS_ID,
-    workflowID: GALAXY_ZOO_BARS_WORKFLOW_ID,
     type: 'classification',
-    period: 'day'
+    userID: USER_ID,
+    workflowID: GALAXY_ZOO_BARS_WORKFLOW_ID
   }).then(function(results) {
     return t.ok(Array.isArray(results), 'Should get an array back');
   });


### PR DESCRIPTION
- updates statsClient to accept user_id, added in https://github.com/zooniverse/zoo-event-stats/pull/83
- refactors queries to data object as per [makeHTTPRequest](https://github.com/zooniverse/json-api-client/blob/master/src/make-http-request.coffee#L30)
- updates related test, though test could be improved, this client will be phased out, so didn't dive into

This functionality will allow the new [Notes from Nature Field Book](https://github.com/zooniverse/notes-from-nature-field-book) to provide user stats in a way greatly desired by the research team and volunteers.