### PR TITLE
Add Variables for a Test Environment

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,36 +4,42 @@ var API_HOSTS = {
   production: 'https://www.zooniverse.org',
   staging: 'https://panoptes-staging.zooniverse.org',
   development: 'https://panoptes-staging.zooniverse.org',
+  test: 'https://panoptes-staging.zooniverse.org'
 };
 
 var API_APPLICATION_IDS = {
   production: 'f79cf5ea821bb161d8cbb52d061ab9a2321d7cb169007003af66b43f7b79ce2a',
   staging: '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27',
   development: '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27',
+  test: '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27'
 };
 
 var OAUTH_HOSTS = {
   production: 'https://panoptes.zooniverse.org',
   staging: 'https://panoptes-staging.zooniverse.org',
   development: 'https://panoptes-staging.zooniverse.org',
+  test: 'https://panoptes-staging.zooniverse.org'
 };
 
 var TALK_HOSTS = {
   production: 'https://talk.zooniverse.org',
   staging: 'https://talk-staging.zooniverse.org',
   development: 'https://talk-staging.zooniverse.org',
+  test: 'https://talk-staging.zooniverse.org'
 };
 
 var SUGAR_HOSTS = {
   production: 'https://notifications.zooniverse.org',
   staging: 'https://notifications-staging.zooniverse.org',
   development: 'https://notifications-staging.zooniverse.org',
+  test: 'https://notifications-staging.zooniverse.org'
 };
 
 var STAT_HOSTS = {
   production: 'https://stats.zooniverse.org',
   staging: 'https://stats-staging.zooniverse.org',
   development: 'https://stats-staging.zooniverse.org',
+  test: 'https://stats-staging.zooniverse.org'
 };
 
 var hostFromBrowser = locationMatch(/\W?panoptes-api-host=([^&]+)/);
@@ -53,7 +59,7 @@ var envFromShell = process.env.NODE_ENV;
 
 var env = envFromBrowser || envFromShell || DEFAULT_ENV;
 
-if (!env.match(/^(production|staging|development)$/)) {
+if (!env.match(/^(production|staging|development|test)$/)) {
   throw new Error('Panoptes Javascript Client Error: Invalid Environment; ' +
     'try setting NODE_ENV to "staging" instead of "'+envFromShell+'".');
 }


### PR DESCRIPTION
This PR adds `test` env variables for several items. This is being added for apps using create-react-app, as the bootstrapper does not allow setting the `NODE_ENV` manually. Thus, running commands like `yarn test` would cause the PJC to throw an error since the `test` env isn't recognized.