### PR TITLE
[WIP] use withCredentials XMLHTTPRequest appropriately

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -212,7 +212,7 @@ module.exports = new Model({
             },
           };
 
-          return makeHTTPRequest('POST', url, data, config.jsonHeaders)
+          return makeCredentialHTTPRequest('POST', url, data, config.jsonHeaders)
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -20,7 +20,7 @@ module.exports = new Model({
   _getBearerToken: function() {
     console.log('Getting bearer token');
     if (this._bearerToken) {
-      console.info('Already had a bearer token', this._bearerToken);
+      console.info('Already had a bearer token');
       return Promise.resolve(this._bearerToken);
     } else {
       var url = config.host + '/oauth/token';

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -134,9 +134,8 @@ module.exports = new Model({
               project_email_communication: given.project_email_communication,
             },
           };
-
-          // This URL is outside the API, but it actually returns a JSON-API response, so handle it with the client.
-          return apiClient.post('/../users', data, config.jsonHeaders)
+          var url = config.host + '/users';
+          return makeCredentialHTTPRequest('POST', url, data, config.jsonHeaders)
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {
@@ -145,9 +144,9 @@ module.exports = new Model({
                 });
               }.bind(this));
             }.bind(this))
-            .catch(function(error) {
+            .catch(function(request) {
               console.error('Failed to register');
-              throw error;
+              return apiClient.handleError(request);
             });
         }.bind(this));
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -325,7 +325,7 @@ module.exports = new Model({
           var deleteHeaders = Object.create(config.jsonHeaders);
           deleteHeaders['X-CSRF-Token'] = token;
 
-          return makeHTTPRequest('DELETE', url, null, deleteHeaders)
+          return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
             .then(function() {
               this._deleteBearerToken();
               this.update({

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -6,12 +6,6 @@ var config = require('./config');
 var apiClient = require('./api-client');
 var getCSRFToken = require('./csrf-token');
 
-// Use this to override the default API-specific headers.
-var JSON_HEADERS = {
-  'Content-Type': 'application/json',
-  'Accept': 'application/json',
-};
-
 // We don't want to wait until the token is already expired before refreshing it.
 var BEARER_TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 
@@ -36,7 +30,7 @@ module.exports = new Model({
         'client_id': config.clientAppID,
       };
 
-      return makeCredentialHTTPRequest('POST', url, data, JSON_HEADERS)
+      return makeCredentialHTTPRequest('POST', url, data, config.jsonHeaders)
         .then(function(request) {
           var token = this._handleNewBearerToken(request);
           console.info('Got bearer token', token.slice(-6));
@@ -78,7 +72,7 @@ module.exports = new Model({
         client_id: config.clientAppID,
       };
 
-      this._tokenRefreshPromise = makeHTTPRequest('POST', url, data, JSON_HEADERS)
+      this._tokenRefreshPromise = makeHTTPRequest('POST', url, data, config.jsonHeaders)
         .then(function(request) {
           var token = this._handleNewBearerToken(request);
           console.info('Refreshed bearer token', token.slice(-6));
@@ -126,7 +120,7 @@ module.exports = new Model({
         }.bind(this));
       } else {
         console.log('Registering new account', given.login);
-        var registrationRequest = getCSRFToken(url, JSON_HEADERS, apiClient).then(function(token) {
+        var registrationRequest = getCSRFToken().then(function(token) {
           var data = {
             authenticity_token: token,
             user: {
@@ -142,7 +136,7 @@ module.exports = new Model({
           };
 
           // This URL is outside the API, but it actually returns a JSON-API response, so handle it with the client.
-          return apiClient.post('/../users', data, JSON_HEADERS)
+          return apiClient.post('/../users', data, config.jsonHeaders)
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {
@@ -218,7 +212,7 @@ module.exports = new Model({
             },
           };
 
-          return makeHTTPRequest('POST', url, data, JSON_HEADERS)
+          return makeHTTPRequest('POST', url, data, config.jsonHeaders)
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {
@@ -257,7 +251,7 @@ module.exports = new Model({
             },
           };
 
-          return apiClient.put('/../users', data, JSON_HEADERS)
+          return apiClient.put('/../users', data, config.jsonHeaders)
             .then(function() {
               // Rough, but it'll do for now. Without signing out and back in, the session is lost.
               return this.signOut();
@@ -284,7 +278,7 @@ module.exports = new Model({
         },
       };
 
-      return apiClient.post('/../users/password', data, JSON_HEADERS);
+      return apiClient.post('/../users/password', data, config.jsonHeaders);
     }.bind(this));
   },
 
@@ -299,7 +293,7 @@ module.exports = new Model({
         },
       };
 
-      return apiClient.put('/../users/password', data, JSON_HEADERS);
+      return apiClient.put('/../users/password', data, config.jsonHeaders);
     }.bind(this));
   },
 
@@ -328,7 +322,7 @@ module.exports = new Model({
         return getCSRFToken().then(function(token) {
           var url = config.host + '/users/sign_out';
 
-          var deleteHeaders = Object.create(JSON_HEADERS);
+          var deleteHeaders = Object.create(config.jsonHeaders);
           deleteHeaders['X-CSRF-Token'] = token;
 
           return makeHTTPRequest('DELETE', url, null, deleteHeaders)
@@ -360,7 +354,7 @@ module.exports = new Model({
         email: given.email,
       };
 
-      return makeHTTPRequest('POST', url, data, JSON_HEADERS);
+      return makeHTTPRequest('POST', url, data, config.jsonHeaders);
     }.bind(this));
   },
 });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,8 +1,10 @@
 var JSONAPIClient = require('json-api-client');
 var Model = JSONAPIClient.Model;
 var makeHTTPRequest = JSONAPIClient.makeHTTPRequest;
+var makeCredentialHTTPRequest = JSONAPIClient.makeCredentialHTTPRequest;
 var config = require('./config');
 var apiClient = require('./api-client');
+var getCSRFToken = require('./csrf-token');
 
 // Use this to override the default API-specific headers.
 var JSON_HEADERS = {
@@ -21,21 +23,6 @@ module.exports = new Model({
   _refreshToken: '',
   _tokenRefreshPromise: null,
 
-  _getAuthToken: function() {
-    console.log('Getting auth token');
-    var url = config.host + '/users/sign_in/?now=' + Date.now();
-    return makeHTTPRequest('GET', url, null, JSON_HEADERS)
-      .then(function(response) {
-        var authToken = response.header['x-csrf-token'];
-        console.info('Got auth token', authToken.slice(-6));
-        return authToken;
-      })
-      .catch(function(response) {
-        console.error('Failed to get auth token');
-        apiClient.handleError(response);
-      });
-  },
-
   _getBearerToken: function() {
     console.log('Getting bearer token');
     if (this._bearerToken) {
@@ -49,7 +36,7 @@ module.exports = new Model({
         'client_id': config.clientAppID,
       };
 
-      return makeHTTPRequest('POST', url, data, JSON_HEADERS)
+      return makeCredentialHTTPRequest('POST', url, data, JSON_HEADERS)
         .then(function(request) {
           var token = this._handleNewBearerToken(request);
           console.info('Got bearer token', token.slice(-6));
@@ -139,7 +126,7 @@ module.exports = new Model({
         }.bind(this));
       } else {
         console.log('Registering new account', given.login);
-        var registrationRequest = this._getAuthToken().then(function(token) {
+        var registrationRequest = getCSRFToken(url, JSON_HEADERS, apiClient).then(function(token) {
           var data = {
             authenticity_token: token,
             user: {
@@ -219,7 +206,7 @@ module.exports = new Model({
         }.bind(this));
       } else {
         console.log('Signing in', credentials.login);
-        var signInRequest = this._getAuthToken().then(function(token) {
+        var signInRequest = getCSRFToken().then(function(token) {
           var url = config.host + '/users/sign_in';
 
           var data = {
@@ -260,7 +247,7 @@ module.exports = new Model({
   changePassword: function(given) {
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return this._getAuthToken().then(function(token) {
+        return getCSRFToken().then(function(token) {
           var data = {
             authenticity_token: token,
             user: {
@@ -289,7 +276,7 @@ module.exports = new Model({
   },
 
   requestPasswordReset: function(given) {
-    return this._getAuthToken().then(function(token) {
+    return getCSRFToken().then(function(token) {
       var data = {
         authenticity_token: token,
         user: {
@@ -302,7 +289,7 @@ module.exports = new Model({
   },
 
   resetPassword: function(given) {
-    return this._getAuthToken().then(function(authToken) {
+    return getCSRFToken().then(function(authToken) {
       var data = {
         authenticity_token: authToken,
         user: {
@@ -338,7 +325,7 @@ module.exports = new Model({
     console.log('Signing out');
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return this._getAuthToken().then(function(token) {
+        return getCSRFToken().then(function(token) {
           var url = config.host + '/users/sign_out';
 
           var deleteHeaders = Object.create(JSON_HEADERS);
@@ -365,7 +352,7 @@ module.exports = new Model({
   },
 
   unsubscribeEmail: function(given) {
-    return this._getAuthToken().then(function(token) {
+    return getCSRFToken().then(function(token) {
       var url = config.host + '/unsubscribe';
 
       var data = {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -252,7 +252,8 @@ module.exports = new Model({
 
           return apiClient.put('/../users', data, config.jsonHeaders)
             .then(function() {
-              // Rough, but it'll do for now. Without signing out and back in, the session is lost.
+              // Resetting the password changes the underlying cookie session data
+              // need to sign out and back in to refresh
               return this.signOut();
             }.bind(this))
             .then(function() {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -120,7 +120,7 @@ module.exports = new Model({
         }.bind(this));
       } else {
         console.log('Registering new account', given.login);
-        var registrationRequest = getCSRFToken().then(function(token) {
+        var registrationRequest = getCSRFToken(config.host).then(function(token) {
           var data = {
             authenticity_token: token,
             user: {
@@ -200,7 +200,7 @@ module.exports = new Model({
         }.bind(this));
       } else {
         console.log('Signing in', credentials.login);
-        var signInRequest = getCSRFToken().then(function(token) {
+        var signInRequest = getCSRFToken(config.host).then(function(token) {
           var url = config.host + '/users/sign_in';
 
           var data = {
@@ -241,7 +241,7 @@ module.exports = new Model({
   changePassword: function(given) {
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return getCSRFToken().then(function(token) {
+        return getCSRFToken(config.host).then(function(token) {
           var data = {
             authenticity_token: token,
             user: {
@@ -270,7 +270,7 @@ module.exports = new Model({
   },
 
   requestPasswordReset: function(given) {
-    return getCSRFToken().then(function(token) {
+    return getCSRFToken(config.host).then(function(token) {
       var data = {
         authenticity_token: token,
         user: {
@@ -283,7 +283,7 @@ module.exports = new Model({
   },
 
   resetPassword: function(given) {
-    return getCSRFToken().then(function(authToken) {
+    return getCSRFToken(config.host).then(function(authToken) {
       var data = {
         authenticity_token: authToken,
         user: {
@@ -319,7 +319,7 @@ module.exports = new Model({
     console.log('Signing out');
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return getCSRFToken().then(function(token) {
+        return getCSRFToken(config.host).then(function(token) {
           var url = config.host + '/users/sign_out';
 
           var deleteHeaders = Object.create(config.jsonHeaders);
@@ -346,7 +346,7 @@ module.exports = new Model({
   },
 
   unsubscribeEmail: function(given) {
-    return getCSRFToken().then(function(token) {
+    return getCSRFToken(config.host).then(function(token) {
       var url = config.host + '/unsubscribe';
 
       var data = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -68,6 +68,11 @@ var defaultParams = {
   http_cache: true
 }
 
+var JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json',
+};
+
 if (typeof location !== 'undefined' && location !== null) {
   var query = window.location.search.substring(1);
   query = query.split('&');
@@ -88,7 +93,8 @@ module.exports = {
   sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
   statHost: statFromBrowser || statFromShell || STAT_HOSTS[env],
   oauthHost: OAUTH_HOSTS[env],
-  params: defaultParams
+  params: defaultParams,
+  jsonHeaders: JSON_HEADERS
 };
 
 // Try and match the location.search property against a regex. Basically mimics

--- a/lib/csrf-token.js
+++ b/lib/csrf-token.js
@@ -3,9 +3,9 @@ var apiClient = require('./api-client');
 var JSONAPIClient = require('json-api-client');
 var makeCredentialHTTPRequest = JSONAPIClient.makeCredentialHTTPRequest;
 
-function getCSRFToken() {
+function getCSRFToken(host) {
   console.log('Getting CSRF token');
-  var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
+  var url = host + '/users/sign_in/?now=' + Date.now();
   return makeCredentialHTTPRequest('GET', url, null, config.jsonHeaders)
     .then(function (response) {
       var csrfToken = response.header['x-csrf-token'];

--- a/lib/csrf-token.js
+++ b/lib/csrf-token.js
@@ -1,10 +1,13 @@
+var config = require('./config');
+var apiClient = require('./api-client');
+
 function getCSRFToken() {
-  console.log('Getting csrf token');
+  console.log('Getting CSRF token');
   var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
-  return makeCredentialHTTPRequest('GET', url, null, JSON_HEADERS)
+  return makeCredentialHTTPRequest('GET', url, null, config.jsonHeaders)
     .then(function (response) {
       var csrfToken = response.header['x-csrf-token'];
-      console.info('Got auth token', csrfToken.slice(-6));
+      console.info('Got CSRF token', csrfToken.slice(-6));
       return csrfToken;
     })
     .catch(function (response) {

--- a/lib/csrf-token.js
+++ b/lib/csrf-token.js
@@ -1,0 +1,16 @@
+function getCSRFToken() {
+  // console.log('Getting csrf token');
+  // var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
+  // return makeCredentialsHTTPRequest('GET', url, null, JSON_HEADERS)
+  //   .then(function (response) {
+  //     var csrfToken = response.header['x-csrf-token'];
+  //     console.info('Got auth token', csrfToken.slice(-6));
+  //     return csrfToken;
+  //   })
+  //   .catch(function (response) {
+  //     console.error('Failed to get csrf token');
+  //     apiClient.handleError(response);
+  //   });
+};
+
+module.exports = getCSRFToken;

--- a/lib/csrf-token.js
+++ b/lib/csrf-token.js
@@ -1,16 +1,16 @@
 function getCSRFToken() {
-  // console.log('Getting csrf token');
-  // var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
-  // return makeCredentialsHTTPRequest('GET', url, null, JSON_HEADERS)
-  //   .then(function (response) {
-  //     var csrfToken = response.header['x-csrf-token'];
-  //     console.info('Got auth token', csrfToken.slice(-6));
-  //     return csrfToken;
-  //   })
-  //   .catch(function (response) {
-  //     console.error('Failed to get csrf token');
-  //     apiClient.handleError(response);
-  //   });
+  console.log('Getting csrf token');
+  var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
+  return makeCredentialHTTPRequest('GET', url, null, JSON_HEADERS)
+    .then(function (response) {
+      var csrfToken = response.header['x-csrf-token'];
+      console.info('Got auth token', csrfToken.slice(-6));
+      return csrfToken;
+    })
+    .catch(function (response) {
+      console.error('Failed to get csrf token');
+      apiClient.handleError(response);
+    });
 };
 
 module.exports = getCSRFToken;

--- a/lib/csrf-token.js
+++ b/lib/csrf-token.js
@@ -1,5 +1,7 @@
 var config = require('./config');
 var apiClient = require('./api-client');
+var JSONAPIClient = require('json-api-client');
+var makeCredentialHTTPRequest = JSONAPIClient.makeCredentialHTTPRequest;
 
 function getCSRFToken() {
   console.log('Getting CSRF token');

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -123,7 +123,7 @@ module.exports = new Model({
     console.log('Signing out');
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return getCSRFToken().then(function(token) {
+        return getCSRFToken(config.oauthHost).then(function(token) {
           var url = config.oauthHost + '/users/sign_out';
 
           var deleteHeaders = Object.create(config.jsonHeaders);

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -7,12 +7,6 @@ var config = require('./config');
 var apiClient = require('./api-client');
 var getCSRFToken = require('./csrf-token');
 
-// Use this to override the default API-specific headers.
-var JSON_HEADERS = {
-  'Content-Type': 'application/json',
-  'Accept': 'application/json',
-};
-
 // We don't want to wait until the token is already expired before refreshing it.
 var TOKEN_EXPIRATION_ALLOWANCE = 5 * 60 * 1000;
 
@@ -132,7 +126,7 @@ module.exports = new Model({
         return getCSRFToken().then(function(token) {
           var url = config.oauthHost + '/users/sign_out';
 
-          var deleteHeaders = Object.create(JSON_HEADERS);
+          var deleteHeaders = Object.create(config.jsonHeaders);
           deleteHeaders['X-CSRF-Token'] = token;
 
           return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,10 +1,11 @@
 var JSONAPIClient = require('json-api-client');
 var Model = JSONAPIClient.Model;
-var makeHTTPRequest = JSONAPIClient.makeHTTPRequest;
+var makeCredentialHTTPRequest = JSONAPIClient.makeCredentialHTTPRequest;
 var ls = require('local-storage');
 
 var config = require('./config');
 var apiClient = require('./api-client');
+var getCSRFToken = require('./csrf-token');
 
 // Use this to override the default API-specific headers.
 var JSON_HEADERS = {
@@ -128,13 +129,13 @@ module.exports = new Model({
     console.log('Signing out');
     return this.checkCurrent().then(function(user) {
       if (user) {
-        return this._getAuthToken().then(function(token) {
+        return getCSRFToken().then(function(token) {
           var url = config.oauthHost + '/users/sign_out';
 
           var deleteHeaders = Object.create(JSON_HEADERS);
           deleteHeaders['X-CSRF-Token'] = token;
 
-          return makeHTTPRequest('DELETE', url, null, deleteHeaders)
+          return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
             .then(function() {
               this._deleteBearerToken();
               this.update({
@@ -226,21 +227,6 @@ module.exports = new Model({
     this._tokenDetails = null;
     delete apiClient.headers.Authorization;
     SESSION_STORAGE.removeItem(LOCAL_STORAGE_PREFIX + 'tokenDetails');
-  },
-
-  _getAuthToken: function() {
-    console.log('Getting auth token');
-    var url = config.oauthHost + '/users/sign_in/?now=' + Date.now();
-    return makeHTTPRequest('GET', url, null, JSON_HEADERS)
-      .then(function(response) {
-        var authToken = response.header['x-csrf-token'];
-        console.info('Got auth token', authToken.slice(-6));
-        return authToken;
-      })
-      .catch(function(response) {
-        console.error('Failed to get auth token');
-        apiClient.handleError(response);
-      });
   },
 
   _getSession: function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,9 +190,9 @@
       }
     },
     "form-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-      "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -314,9 +314,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "json-api-client": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-4.0.2.tgz",
-      "integrity": "sha512-Hxki1EGD8J3hdvAWo6cQy5aCcVH/VT6hzrYF9VTuy6lkvZaXPfodQR5p5Vh2Zc/SUl/yvcp2l7RHPiqUgpzQmA==",
+      "version": "5.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0-rc.0.tgz",
+      "integrity": "sha512-xnGt9yfU9s3v7Lll3gEVY1xJd/auR0AaLmph2KBhK9CclrSxfpoP9rvMX5Qh1A7CBjIGai0JpJm8bjTWf9o2Yw==",
       "requires": {
         "normalizeurl": "~0.1.3",
         "superagent": "^3.8.3"
@@ -344,16 +344,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.42.0"
       }
     },
     "minimatch": {
@@ -455,9 +455,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
     },
     "re-emitter": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "dependencies": {
-    "json-api-client": "file:/Users/camallen/workspace/zooniverse/json-api-client",
+    "json-api-client": "file:../json-api-client",
     "local-storage": "^1.4.2",
     "sugar-client": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "dependencies": {
-    "json-api-client": "^4.0.2",
+    "json-api-client": "file:/Users/camallen/workspace/zooniverse/json-api-client",
     "local-storage": "^1.4.2",
     "sugar-client": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "dependencies": {
-    "json-api-client": "file:../json-api-client",
+    "json-api-client": "~5.0.0-rc.0",
     "local-storage": "^1.4.2",
     "sugar-client": "^1.0.1"
   },

--- a/test/auth.js
+++ b/test/auth.js
@@ -16,7 +16,7 @@ test('Checking the current user initially fails', function(t) {
     });
 });
 
-test.only('Registering an account with no data fails', function(t) {
+test('Registering an account with no data fails', function(t) {
   var BLANK_REGISTRATION = {};
   return auth.register(BLANK_REGISTRATION)
     .then(function() {

--- a/test/auth.js
+++ b/test/auth.js
@@ -16,7 +16,7 @@ test('Checking the current user initially fails', function(t) {
     });
 });
 
-test('Registering an account with no data fails', function(t) {
+test.only('Registering an account with no data fails', function(t) {
   var BLANK_REGISTRATION = {};
   return auth.register(BLANK_REGISTRATION)
     .then(function() {


### PR DESCRIPTION
Use the underlying credentialed / non-credentialed http requests in https://github.com/zooniverse/json-api-client/pull/52 to avoid CORS issues for open resources on the API.

The underlying issue is that an API change to cors implementation in https://github.com/zooniverse/Panoptes/pull/3199 ensures that all public (wildcard) origins disallows credentialed requests, i.e. our API allows `{ origins: '*', resource: 'api/*'}` so these resources can't be accessed with credentialed requests. As it stands our `json-api-client` always attaches uses `withCredentials` which is a risk of leaking private data. 