### PR TITLE
Change default oAuth Host and allow config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,7 @@ var API_APPLICATION_IDS = {
 };
 
 var OAUTH_HOSTS = {
-  production: 'https://panoptes.zooniverse.org',
+  production: 'https://www.zooniverse.org',
   staging: 'https://panoptes-staging.zooniverse.org',
   development: 'https://panoptes-staging.zooniverse.org',
   test: 'https://panoptes-staging.zooniverse.org'

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,12 +47,14 @@ var appFromBrowser = locationMatch(/\W?panoptes-api-application=([^&]+)/);
 var talkFromBrowser = locationMatch(/\W?talk-host=([^&]+)/);
 var sugarFromBrowser = locationMatch(/\W?sugar-host=([^&]+)/);
 var statFromBrowser = locationMatch(/\W?stat-host=([^&]+)/);
+var oauthFromBrowser = locationMatch(/\W?oauth-host=([^&]+)/);
 
 var hostFromShell = process.env.PANOPTES_API_HOST;
 var appFromShell = process.env.PANOPTES_API_APPLICATION;
 var talkFromShell = process.env.TALK_HOST;
 var sugarFromShell = process.env.SUGAR_HOST;
 var statFromShell = process.env.STAT_HOST;
+var oauthFromShell = process.env.OAUTH_HOST;
 
 var envFromBrowser = locationMatch(/\W?env=(\w+)/);
 var envFromShell = process.env.NODE_ENV;
@@ -92,7 +94,7 @@ module.exports = {
   talkHost: talkFromBrowser || talkFromShell || TALK_HOSTS[env],
   sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
   statHost: statFromBrowser || statFromShell || STAT_HOSTS[env],
-  oauthHost: OAUTH_HOSTS[env],
+  oauthHost: oauthFromBrowser || oauthFromShell || OAUTH_HOSTS[env],
   params: defaultParams,
   jsonHeaders: JSON_HEADERS
 };


### PR DESCRIPTION
## PR Overview

This PR changes PJC's oAuth host:

- The default oAuth host is now `www.zooniverse.org` instead of `panoptes.zooniverse.org`, to reflect current changes to the backend. That's right! oAuth users now sign in via our "main domain" instead of the `panoptes.` sub-domain.
- The oAuth host can now also be changed either by setting `?oauth-host=...` in the browser, or setting `OAUTH_HOST` in the env build variables. This brings the oAuth host config setting in line with other editable items in the PJC's config.

To Custom Front End developers:

- This change will allow **single sign on** across all `*.zooniverse.org` domains (if you use the oauth.js code)
- If you implement these changes, you should see **no changes** to sign-in functionality. The only difference should be that when users login, they see a different Zooniverse.org domain asking for their user/pass. 
- Users who are still logged in when you push the changes, however, might find themselves logged out afterwards.

Tested using a local copy of PJC and localhost Education API Front End, which was used to verify the single sign on.

### Status

Ready for review. If all goes well, this might only require a _minor_ version bump since it's not breaking any existing functionality - but let me know if you think otherwise.