### PR TITLE
Check for Custom ENV Variable from CRA

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -57,9 +57,10 @@ var statFromShell = process.env.STAT_HOST;
 var oauthFromShell = process.env.OAUTH_HOST;
 
 var envFromBrowser = locationMatch(/\W?env=(\w+)/);
+const envFromCreateReactApp = process.env.REACT_APP_ENV
 var envFromShell = process.env.NODE_ENV;
 
-var env = envFromBrowser || envFromShell || DEFAULT_ENV;
+var env = envFromBrowser || envFromCreateReactApp || envFromShell || DEFAULT_ENV;
 
 if (!env.match(/^(production|staging|development|test)$/)) {
   throw new Error('Panoptes Javascript Client Error: Invalid Environment; ' +

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,7 @@ var statFromShell = process.env.STAT_HOST;
 var oauthFromShell = process.env.OAUTH_HOST;
 
 var envFromBrowser = locationMatch(/\W?env=(\w+)/);
-const envFromCreateReactApp = process.env.REACT_APP_ENV
+var envFromCreateReactApp = process.env.REACT_APP_ENV
 var envFromShell = process.env.NODE_ENV;
 
 var env = envFromBrowser || envFromCreateReactApp || envFromShell || DEFAULT_ENV;


### PR DESCRIPTION
This PR adds a check in the config file for an environment variable set via Create React App. This is necessary for deploying ALICE to staging. 

ALICE is built using Create React App, which strictly sets `NODE_ENV` to `production` when running `react-scripts build`. Although you can [set custom variables](https://create-react-app.dev/docs/deployment/#customizing-environment-variables-for-arbitrary-build-environments) (like `REACT_APP_ENV`), you are not allowed to change the node environment (see Special Thanks on [link](https://dev.to/jam3/managing-env-variables-for-provisional-builds-h37)), as it is strictly set.

You can eject Create React App to set the `NODE_ENV`, but this is a pretty drastic thing to do, and you lose all the convenience of having CRA handle your dependencies.