### PR TITLE
Auth clients: Hide private data from exports

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -367,6 +367,7 @@ module.exports = {
   listen: authClient.listen.bind(authClient),
   register: authClient.register.bind(authClient),
   requestPasswordReset: authClient.requestPasswordReset.bind(authClient),
+  resetPassword: authClient.resetPassword.bind(authClient),
   signIn: authClient.signIn.bind(authClient),
   stopListening: authClient.stopListening.bind(authClient),
   signOut: authClient.signOut.bind(authClient),

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ var getCSRFToken = require('./csrf-token');
 // We don't want to wait until the token is already expired before refreshing it.
 var BEARER_TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
 
-module.exports = new Model({
+const authClient = new Model({
   _currentUserPromise: null,
 
   _bearerToken: '',
@@ -358,3 +358,15 @@ module.exports = new Model({
     }.bind(this));
   },
 });
+
+module.exports = {
+  register: authClient.register.bind(authClient),
+  checkCurrent: authClient.checkCurrent.bind(authClient),
+  checkBearerToken: authClient.checkBearerToken.bind(authClient),
+  signIn: authClient.signIn.bind(authClient),
+  changePassword: authClient.changePassword.bind(authClient),
+  requestPasswordReset: authClient.requestPasswordReset.bind(authClient),
+  disableAccount: authClient.disableAccount.bind(authClient),
+  signOut: authClient.signOut.bind(authClient),
+  unsubscribeEmail: authClient.unsubscribeEmail.bind(authClient)
+};

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -360,13 +360,15 @@ const authClient = new Model({
 });
 
 module.exports = {
-  register: authClient.register.bind(authClient),
+  changePassword: authClient.changePassword.bind(authClient),
   checkCurrent: authClient.checkCurrent.bind(authClient),
   checkBearerToken: authClient.checkBearerToken.bind(authClient),
-  signIn: authClient.signIn.bind(authClient),
-  changePassword: authClient.changePassword.bind(authClient),
-  requestPasswordReset: authClient.requestPasswordReset.bind(authClient),
   disableAccount: authClient.disableAccount.bind(authClient),
+  listen: authClient.listen.bind(authClient),
+  register: authClient.register.bind(authClient),
+  requestPasswordReset: authClient.requestPasswordReset.bind(authClient),
+  signIn: authClient.signIn.bind(authClient),
+  stopListening: authClient.stopListening.bind(authClient),
   signOut: authClient.signOut.bind(authClient),
   unsubscribeEmail: authClient.unsubscribeEmail.bind(authClient)
 };

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -17,7 +17,7 @@ var LOCAL_STORAGE_PREFIX = 'panoptesClientOAuth_';
 var SESSION_STORAGE = window.localStorage;
 
 // Create our model, then do stuff with it later
-module.exports = new Model({
+const authClient = new Model({
   _bearerRefreshTimeout: NaN,
   _clientAppId: ls.get(LOCAL_STORAGE_PREFIX + 'clientAppId'),
   _currentSessionCheckPromise: null,
@@ -311,4 +311,12 @@ function createIFrame(url) {
 function destroyIFrame(iframe) {
   iframe.parentNode.removeChild(iframe);
   return null;
+}
+
+module.exports = {
+  checkCurrent: authClient.checkCurrent.bind(authClient),
+  checkBearerToken: authClient.checkBearerToken.bind(authClient),
+  init: authClient.init.bind(authClient),
+  signIn: authClient.signIn.bind(authClient),
+  signOut: authClient.signOut.bind(authClient)
 }

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -317,6 +317,8 @@ module.exports = {
   checkCurrent: authClient.checkCurrent.bind(authClient),
   checkBearerToken: authClient.checkBearerToken.bind(authClient),
   init: authClient.init.bind(authClient),
+  listen: authClient.listen.bind(authClient),
+  stopListening: authClient.stopListening.bind(authClient),
   signIn: authClient.signIn.bind(authClient),
   signOut: authClient.signOut.bind(authClient)
 }


### PR DESCRIPTION
Hide underscored methods and properties from the exported `auth` and `oauth` clients.

~~Change the signature of `auth.checkBearerToken()` so that it resolves true/false rather than resolving with the bearer token.~~

`npm install zooniverse/panoptes-javascript-client#private-data` to try this out.