### PR TITLE
Remove auth test module

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,1 @@
-require('./auth');
 require('./stats');


### PR DESCRIPTION
Closes #138 

When #124 was merged we forgot to remove the line that tries to test the `./auth` test file. This removes that line and allows `npm run test` to run again