### PR TITLE
increase token expiration allowance to 300s (5mins)

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -7,7 +7,8 @@ var apiClient = require('./api-client');
 var getCSRFToken = require('./csrf-token');
 
 // We don't want to wait until the token is already expired before refreshing it.
-var BEARER_TOKEN_EXPIRATION_ALLOWANCE = 60 * 1000;
+// attempt to get a new token 5mins (300sec) before the current one expires
+var BEARER_TOKEN_EXPIRATION_ALLOWANCE = 300 * 1000;
 
 const authClient = new Model({
   _currentUserPromise: null,


### PR DESCRIPTION
linked to reports of folks submitting classifications but not having them attributed to their account (i.e. not linked to the user), https://www.zooniverse.org/projects/douglas-clark/the-arctic-bears-project/talk/2102/1955932?comment=3221410

In theory these events should be rare but there are known service issues with the K8s ingress where it temporarily loses the ability to route traffic to the service pods and thus this could be exacerbating this issue.

I theorized that this event could happen if the request to refresh a token fails or times out (due to network or API service issues) and in the interim period when the current token expires there is no request to the API to refresh it again. 

Thus this PR introduces a change to refresh the token at a much earlier point (5 mins vs 1 min) and thus increases the window that any failed refresh token event can recover from transient API failures. 