### PR TITLE
Sugar client: fix Panoptes authentication

### DIFF
--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -22,7 +22,7 @@ if (typeof navigator !== 'undefined') {
   var sugarClient = new SugarClient();
 
   auth.listen('change', function() {
-    Promise.all(auth.checkCurrent(), auth.checkBearerToken())
+    Promise.all([auth.checkCurrent(), auth.checkBearerToken()])
       .then(function([ user, token ]) {
         if (user && token) {
           sugarClient.userId = user.id;
@@ -41,6 +41,7 @@ if (typeof navigator !== 'undefined') {
         }
       })
       .catch(function(e) {
+        console.error(e)
         throw new Error('Failed to checkCurrent auth from sugar client');
       });
   });

--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -22,11 +22,14 @@ if (typeof navigator !== 'undefined') {
   var sugarClient = new SugarClient();
 
   auth.listen('change', function() {
-    Promise.all([auth.checkCurrent(), auth.checkBearerToken()])
-      .then(function([ user, token ]) {
-        if (user && token) {
+    auth.checkCurrent()
+      .then(function(user) {
+        if (user) {
           sugarClient.userId = user.id;
-          sugarClient.authToken = token;
+          auth.checkBearerToken()
+            .then(function (token) {
+              sugarClient.authToken = token;
+            })
 
           if (process.env.NODE_ENV !== 'production') {
             sugarClient.on('response', function() {

--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -29,6 +29,7 @@ if (typeof navigator !== 'undefined') {
           auth.checkBearerToken()
             .then(function (token) {
               sugarClient.authToken = token;
+              sugarClient.connect();
             })
 
           if (process.env.NODE_ENV !== 'production') {
@@ -37,8 +38,6 @@ if (typeof navigator !== 'undefined') {
               console.log.apply(console, ['[SUGAR RESPONSE]'].concat(args));
             });
           }
-
-          sugarClient.connect();
         } else {
           sugarClient.disconnect();
         }


### PR DESCRIPTION
Missed in #135: `Promise.all` should take an array as an argument. I've also added better error-logging to debug Sugar client errors.