### PR TITLE
Update sugar-client to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -546,9 +546,9 @@
       }
     },
     "sugar-client": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.0.1.tgz",
-      "integrity": "sha1-zRhz+/Kn2smm8prKHq2hr3UTz58="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
+      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA=="
     },
     "superagent": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "json-api-client": "~5.0.0",
     "local-storage": "^1.4.2",
-    "sugar-client": "^1.0.1"
+    "sugar-client": "^1.1.0"
   },
   "devDependencies": {
     "blue-tape": "~1.0.0",


### PR DESCRIPTION
This is a minor update to the sugar client that did two things: decaffeinate the coffeescript of the client and remove the build tools of browserify, watchify, uglify. The browserify build tools weren't even being used. The coffeescript version it used was very old and although there had been updates since, the coffeescript project is moving very slow these days. Decaffeinating the client seems the best way forward.

This should be tested using npm link with PFE to confirm that it doesn't break the notification system. 