### PR TITLE
Return a token from auth._refreshBearerToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix undefined token in `auth.checkBearerToken()` after a token refresh.
+  
 ## v3.3.3
 
 Sugar client updated to decaffeinated version. 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -77,13 +77,16 @@ const authClient = new Model({
         .then(function(request) {
           var token = this._handleNewBearerToken(request);
           console.info('Refreshed bearer token', token.slice(-6));
+          return token;
         }.bind(this))
         .catch(function(request) {
           console.error('Failed to refresh bearer token');
           apiClient.handleError(request);
+          return '';
         })
-        .then(function() {
+        .then(function(token) {
           this._tokenRefreshPromise = null;
+          return token
         }.bind(this));
     }
 


### PR DESCRIPTION
Return the refreshed token, or an empty string, from `auth._refreshBearerToken()`. This should fix token-handling for code that expects `auth.checkBearerToken()` to return a valid token.