### PR TITLE
Reject the returned promise on error

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -15,7 +15,7 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   handleError: function(response) {
     var errorMessage;
     if (response instanceof Error) {
-      throw response;
+      return Promise.reject(response);
     } else if (response.body && typeof response.body === 'object') {
       if (response.body.error) {
         errorMessage = response.body.error;
@@ -39,10 +39,9 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
       errorMessage = 'Unknown error (bad response)';
     }
 
-    var e = new Error(errorMessage);
-    e.status = response.status;
-    e.statusText = response.statusText;
-    throw e;
+    console.warn(errorMessage)
+    response.message = errorMessage
+    return Promise.reject(response);
   }
 });
 


### PR DESCRIPTION
Reject the returned promise after catching an API error, rather than re-throwing the error.

This might make the PFE error logs less noisy, since we don't really want to error for 404 responses etc.

To install this in `npm` projects like PFE, point the `panoptes-client` package to this branch in `package.json`.
```json
"panoptes-client": "zooniverse/panoptes-javascript-client#reject-on-error",
```

then `npm ci` (or `npm ci --legacy-peer-deps` for older projects.)