### PR TITLE
remove *FromBrowser config directives

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,13 +42,6 @@ var STAT_HOSTS = {
   test: 'https://stats-staging.zooniverse.org'
 };
 
-var hostFromBrowser = locationMatch(/\W?panoptes-api-host=([^&]+)/);
-var appFromBrowser = locationMatch(/\W?panoptes-api-application=([^&]+)/);
-var talkFromBrowser = locationMatch(/\W?talk-host=([^&]+)/);
-var sugarFromBrowser = locationMatch(/\W?sugar-host=([^&]+)/);
-var statFromBrowser = locationMatch(/\W?stat-host=([^&]+)/);
-var oauthFromBrowser = locationMatch(/\W?oauth-host=([^&]+)/);
-
 var hostFromShell = process.env.PANOPTES_API_HOST;
 var appFromShell = process.env.PANOPTES_API_APPLICATION;
 var talkFromShell = process.env.TALK_HOST;
@@ -90,12 +83,12 @@ if (typeof location !== 'undefined' && location !== null) {
 }
 
 module.exports = {
-  host: hostFromBrowser || hostFromShell || API_HOSTS[env],
-  clientAppID: appFromBrowser || appFromShell || API_APPLICATION_IDS[env],
-  talkHost: talkFromBrowser || talkFromShell || TALK_HOSTS[env],
-  sugarHost: sugarFromBrowser || sugarFromShell || SUGAR_HOSTS[env],
-  statHost: statFromBrowser || statFromShell || STAT_HOSTS[env],
-  oauthHost: oauthFromBrowser || oauthFromShell || OAUTH_HOSTS[env],
+  host: hostFromShell || API_HOSTS[env],
+  clientAppID: appFromShell || API_APPLICATION_IDS[env],
+  talkHost: talkFromShell || TALK_HOSTS[env],
+  sugarHost: sugarFromShell || SUGAR_HOSTS[env],
+  statHost: statFromShell || STAT_HOSTS[env],
+  oauthHost: oauthFromShell || OAUTH_HOSTS[env],
   params: defaultParams,
   jsonHeaders: JSON_HEADERS
 };


### PR DESCRIPTION
these aren't useful in deployed systems, instead rely on `*FromShell` config overrides for development