### PR TITLE
Bump version 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v4.0.1](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.0.1) (2022-09-30)
+
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.1.0...v4.0.0)
+
+**Merged pull requests:**
+- add CI system to run what tests there are (#167)
+[\#167](https://github.com/zooniverse/panoptes-javascript-client/pull/167)
+- remove *FromBrowser config directives (#166)
+[\#166](https://github.com/zooniverse/panoptes-javascript-client/pull/166)
+- Bump json-api-client from 6.0.0 to 6.0.1
+[\#165](https://github.com/zooniverse/panoptes-javascript-client/pull/165)
+- Upgrade superagent to 8.0.0. Drop IE support.
+[\#162](https://github.com/zooniverse/panoptes-javascript-client/pull/162)
+
 ## [v4.0.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.0.0) (2022-06-30)
 
 [Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.0.0...v3.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 [Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.1.0...v4.0.0)
 
 **Merged pull requests:**
-- add CI system to run what tests there are (#167)
+- add CI system to run what tests there are
 [\#167](https://github.com/zooniverse/panoptes-javascript-client/pull/167)
-- remove *FromBrowser config directives (#166)
+- remove *FromBrowser config directives
 [\#166](https://github.com/zooniverse/panoptes-javascript-client/pull/166)
 - Bump json-api-client from 6.0.0 to 6.0.1
 [\#165](https://github.com/zooniverse/panoptes-javascript-client/pull/165)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptes-client",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptes-client",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "json-api-client": "~6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
this should be a minor version update - however it may have breaking changes with the superagent / json api client updates.

Should we change to a major version bump ?