### PR TITLE
Version 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
+## [v4.1.1](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.1.1) (2022-10-03)
+
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.1.0...v4.1.1)
+
+**Merged pull requests:**
+- Bump json-api-client from 6.0.1 to 6.0.2
+[\#169](https://github.com/zooniverse/panoptes-javascript-client/pull/169)
+
 ## [v4.1.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.1.0) (2022-09-30)
 
-[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.1.0...v4.0.0)
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.0.0...v4.1.0)
 
 **Merged pull requests:**
 - add CI system to run what tests there are
@@ -14,7 +22,7 @@
 
 ## [v4.0.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.0.0) (2022-06-30)
 
-[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.0.0...v3.4.1)
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v3.4.1...v4.0.0)
 
 **Merged pull requests:**
 - Upgrade superagent to 8.0.0. Drop IE support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Includes a bump of superagent from 8.0.1 to 8.0.2, via `json-api-client@6.0.2`