### PR TITLE
Convert error responses to Error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased](https://github.com/zooniverse/panoptes-javascript-client/tree/master) (2022-11-01)
+
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.1...master)
+
+**Merged pull requests:**
+- Convert error responses to Error objects
+[\#175](https://github.com/zooniverse/panoptes-javascript-client/pull/175)
+
 ## [v4.2.1](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.2.1) (2022-10-25)
 
 [Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.0...v4.2.1)
@@ -9,7 +17,7 @@
 
 **Merged pull requests:**
 - Bump json-api-client from 6.0.2 to 6.0.3
-[\#169](https://github.com/zooniverse/panoptes-javascript-client/pull/173)
+[\#173](https://github.com/zooniverse/panoptes-javascript-client/pull/173)
 
 ## [v4.2.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.2.0) (2022-10-12)
 

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -39,9 +39,11 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
       errorMessage = 'Unknown error (bad response)';
     }
 
-    console.warn(errorMessage)
-    response.message = errorMessage
-    return Promise.reject(response);
+    console.warn(errorMessage);
+    var e = new Error(errorMessage);
+    e.status = response.status;
+    e.statusText = response.statusText;
+    return Promise.reject(e);
   }
 });
 


### PR DESCRIPTION
Consumers of this client expect promises to reject with an [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), not the API response body, so convert the response to an Error object before rejecting the returned promise.

Follow-up to #164. See https://github.com/zooniverse/Panoptes-Front-End/issues/6234 and https://github.com/zooniverse/Panoptes-Front-End/issues/6232.