### PR TITLE
Version 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [Unreleased](https://github.com/zooniverse/panoptes-javascript-client/tree/master) (2022-11-01)
+## [v4.2.2](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.2.2) (2022-11-03)
 
-[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.1...master)
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.1...v4.2.2)
 
 **Merged pull requests:**
 - Convert error responses to Error objects

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptes-client",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptes-client",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "json-api-client": "~6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Converts Panoptes API response bodies to errors, for downstream clients that expect an `Error` object from rejected promises.

Some apps catch errors like this:
```js
apiClient.get(something)
.catch(error => error.toString())
```

`error.toString()` returns the error message for instances of [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error). Otherwise, it returns `[object Object]`.
```