### PR TITLE
lib/auth: Return login errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased](https://github.com/zooniverse/panoptes-javascript-client/tree/master) (2022-11-03)
+
+[Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.2...master)
+
+**Closed issues:**
+
+- First party auth doesn't return login errors [\#177](https://github.com/zooniverse/panoptes-javascript-client/issues/177)
+
+**Merged pull requests:**
+- lib/auth: Return login errors
+[\#178](https://github.com/zooniverse/panoptes-javascript-client/pull/178)
+
 ## [v4.2.2](https://github.com/zooniverse/panoptes-javascript-client/tree/v4.2.2) (2022-11-03)
 
 [Full Changelog](https://github.com/zooniverse/panoptes-javascript-client/compare/v4.2.1...v4.2.2)

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -226,7 +226,7 @@ const authClient = new Model({
             }.bind(this))
             .catch(function(request) {
               console.error('Failed to sign in');
-              apiClient.handleError(request);
+              return apiClient.handleError(request);
             });
         }.bind(this));
 


### PR DESCRIPTION
Make sure that the request promise is rejected with an error when login fails. Otherwise, it resolves with an undefined user.

This is based off #176, so merge that first.

- Fixes #177.
- See also https://github.com/zooniverse/Panoptes-Front-End/issues/6236.