### PR TITLE
Add Resource methods to ResourcePromise

### DIFF
--- a/lib/json-api-client/resource.js
+++ b/lib/json-api-client/resource.js
@@ -346,6 +346,10 @@
       uncacheLink(...args) {
         return this.api('uncacheLink', ...args);
       }
+
+      getChangesSinceSave(...args) {
+        return this.api('getChangesSinceSave', ...args);
+      }
     };
 
     ResourcePromise.prototype._promise = null;

--- a/lib/json-api-client/resource.js
+++ b/lib/json-api-client/resource.js
@@ -323,6 +323,29 @@
         return this.api('update', ...args);
       }
 
+      refresh(...args) {
+        return this.api('refresh', ...args);
+      }
+
+      uncache(...args) {
+        return this.api('uncache', ...args);
+      }
+
+      getMeta(...args) {
+        return this.api('getMeta', ...args);
+      }
+
+      addLink(...args) {
+        return this.api('addLink', ...args);
+      }
+
+      removeLink(...args) {
+        return this.api('removeLink', ...args);
+      }
+
+      uncacheLink(...args) {
+        return this.api('uncacheLink', ...args);
+      }
     };
 
     ResourcePromise.prototype._promise = null;


### PR DESCRIPTION
Update the `ResourcePromise` interface to match `Resource`, so that we can do the same things with resource promises that we do with resources.

Eg.
- `client.type().get().addLink()`
- `resource.save().addLink()`