### PR TITLE
Add default JSON headers to sign-out requests

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -326,8 +326,10 @@ const authClient = new Model({
         return getCSRFToken(config.host).then(function(token) {
           var url = config.host + '/users/sign_out';
 
-          var deleteHeaders = Object.create(config.jsonHeaders);
-          deleteHeaders['X-CSRF-Token'] = token;
+          var deleteHeaders = {
+            ...config.jsonHeaders,
+            ['X-CSRF-Token']: token
+          };
 
           return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
             .then(function() {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -126,8 +126,10 @@ const authClient = new Model({
         return getCSRFToken(config.oauthHost).then(function(token) {
           var url = config.oauthHost + '/users/sign_out';
 
-          var deleteHeaders = Object.create(config.jsonHeaders);
-          deleteHeaders['X-CSRF-Token'] = token;
+          var deleteHeaders = {
+            ...config.jsonHeaders,
+            ['X-CSRF-Token']: token
+          };
 
           return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
             .then(function() {


### PR DESCRIPTION
Add the enumerable values of `config.jsonHeaders` to `deleteHeaders`, rather than [creating a new, empty object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#syntax) from its prototype.

Closes #197.