### PR TITLE
Use credentialed requests for password updates

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -254,7 +254,8 @@ const authClient = new Model({
             },
           };
 
-          return apiClient.put('/../users', data, config.jsonHeaders)
+          const url = config.host + '/users';
+          return makeCredentialHTTPRequest('PUT', url, data, config.jsonHeaders)
             .then(function() {
               // Resetting the password changes the underlying cookie session data
               // need to sign out and back in to refresh
@@ -297,7 +298,8 @@ const authClient = new Model({
         },
       };
 
-      return apiClient.put('/../users/password', data, config.jsonHeaders);
+      const url = config.host + '/users/password';
+      return makeCredentialHTTPRequest('PUT', url, data, config.jsonHeaders);
     }.bind(this));
   },
 


### PR DESCRIPTION
Swap `apiClient.put` for `makeCredentialHTTPRequest` in `auth.changePassword` and `auth.resetPassword`.

This should allow those client methods to work even when the client and the API are not on the same origin eg. when using the staging API.

Closes #199.

I've set up https://github.com/zooniverse/Panoptes-Front-End/pull/6436 to test this branch, so you can try out the changes on https://pr-6436.pfe-preview.zooniverse.org.