### PR TITLE
Refactor signOut with async/await

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -321,37 +321,35 @@ const authClient = new Model({
     }.bind(this));
   },
 
-  signOut: function() {
+  async signOut() {
     console.log('Signing out');
-    return this.checkCurrent().then(function(user) {
-      if (user) {
-        return getCSRFToken(config.host).then(function(token) {
-          var url = config.host + '/users/sign_out';
+    const user = await this.checkCurrent();
+    if (user) {
+      const token = await getCSRFToken(config.host);
+      const url = config.host + '/users/sign_out';
+      const bearerToken = await this.checkBearerToken();
 
-          var deleteHeaders = {
-            ...config.jsonHeaders,
-            ['X-CSRF-Token']: token,
-            ['Authorization']: 'Bearer ' + this._bearerToken
-          };
+      const deleteHeaders = {
+        ...config.jsonHeaders,
+        ['X-CSRF-Token']: token,
+        ['Authorization']: 'Bearer ' + bearerToken
+      };
 
-          return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
-            .then(function() {
-              this._deleteBearerToken();
-              this.update({
-                _currentUserPromise: Promise.resolve(null),
-              });
-              console.info('Signed out');
-              return null;
-            }.bind(this))
-            .catch(function(request) {
-              console.error('Failed to sign out');
-              return apiClient.handleError(request);
-            }.bind(this));
-        }.bind(this));
-      } else {
-        throw new Error('Failed to sign out; not signed in');
+      try {
+        makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders);
+        this._deleteBearerToken();
+        this.update({
+          _currentUserPromise: Promise.resolve(null),
+        });
+        console.info('Signed out');
+        return null;
+      } catch (error) {
+        console.error('Failed to sign out');
+        return apiClient.handleError(error);
       }
-    }.bind(this));
+    } else {
+      throw new Error('Failed to sign out; not signed in');
+    }
   },
 
   unsubscribeEmail: function(given) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -119,40 +119,38 @@ const authClient = new Model({
       }.bind(this));
   },
 
-  signOut: function() {
+  async signOut() {
     console.log('Signing out');
-    return this.checkCurrent().then(function(user) {
-      if (user) {
-        return getCSRFToken(config.oauthHost).then(function(token) {
-          var url = config.oauthHost + '/users/sign_out';
+    const user = await this.checkCurrent();
+    if (user) {
+      const token = await getCSRFToken(config.oauthHost);
+      const url = config.oauthHost + '/users/sign_out';
+      const tokenDetails = await this.checkBearerToken();
 
-          var deleteHeaders = {
-            ...config.jsonHeaders,
-            ['X-CSRF-Token']: token
-          };
+      const deleteHeaders = {
+        ...config.jsonHeaders,
+        ['X-CSRF-Token']: token
+      };
 
-          if (this._tokenDetails && this._tokenDetails.access_token) {
-            deleteHeaders['Authorization'] = 'Bearer ' + this._tokenDetails.access_token
-          }
-
-          return makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
-            .then(function() {
-              this._deleteBearerToken();
-              this.update({
-                _currentUserPromise: Promise.resolve(null),
-              });
-              console.info('Signed out');
-              return null;
-            }.bind(this))
-            .catch(function(request) {
-              console.error('Failed to sign out');
-              return apiClient.handleError(request);
-            }.bind(this));
-        }.bind(this));
-      } else {
-        throw new Error('Failed to sign out; not signed in');
+      if (tokenDetails && tokenDetails.access_token) {
+        deleteHeaders['Authorization'] = 'Bearer ' + tokenDetails.access_token
       }
-    }.bind(this));
+
+      try {
+        makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
+        this._deleteBearerToken();
+        this.update({
+          _currentUserPromise: Promise.resolve(null),
+        });
+        console.info('Signed out');
+        return null;
+      } catch (error) {
+        console.error('Failed to sign out');
+        return apiClient.handleError(error);
+      }
+    } else {
+      throw new Error('Failed to sign out; not signed in');
+    }
   },
 
   _createOAuthUrl: function(redirectUri) {


### PR DESCRIPTION
Refactor `auth.signOut` and `oauth.signOut` to remove nested promises and `.bind(this)` on inner functions. Use `async/await` instead, for better readability.

Use `auth.checkBearerToken()` to get the bearer token for the DELETE request.