### PR TITLE
Sugar client: add token refresh

### DIFF
--- a/lib/SugarClient/client.js
+++ b/lib/SugarClient/client.js
@@ -1,3 +1,5 @@
+var auth = require('../auth');
+
 class SugarClient {
   static initClass() {
     this.host = null;
@@ -6,6 +8,7 @@ class SugarClient {
 
   constructor(userId, authToken) {
     this.primusUrl = this.primusUrl.bind(this);
+    this.refreshToken = this.refreshToken.bind(this);
     this.connect = this.connect.bind(this);
     this.disconnect = this.disconnect.bind(this);
     this.receiveData = this.receiveData.bind(this);
@@ -42,8 +45,14 @@ class SugarClient {
     return SugarClient.host;
   }
 
+  async refreshToken() {
+    const token = await auth.checkBearerToken();
+    this.authToken = token;
+  }
+
   primusUrl(baseUrl) {
     if (this.userId && this.authToken) {
+      this.refreshToken()
       return baseUrl.query = `user_id=${ this.userId }&auth_token=${ this.authToken }`;
     }
   }

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -8,6 +8,8 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   params: config.params,
 
   beforeEveryRequest: function() {
+    var { sugarClient } = require('./sugar');
+    sugarClient.refreshToken();
     var auth = require('./auth');
     return auth.checkBearerToken();
   },


### PR DESCRIPTION
Add `client.refreshToken()` to the Sugar client. Call it whenever `client.primusUrl()` generates a URL for the Primus service.