### PR TITLE
Improved Sugar client token refresh flow

### DIFF
--- a/lib/SugarClient/client.js
+++ b/lib/SugarClient/client.js
@@ -45,14 +45,16 @@ class SugarClient {
     return SugarClient.host;
   }
 
-  async refreshToken() {
-    const token = await auth.checkBearerToken();
-    this.authToken = token;
+  async refreshToken(token) {
+    const tokenChanged = token !== this.authToken;
+    if (this.userId && tokenChanged) {
+      this.authToken = token;
+      this.connect();
+    }
   }
 
   primusUrl(baseUrl) {
     if (this.userId && this.authToken) {
-      this.refreshToken()
       return baseUrl.query = `user_id=${ this.userId }&auth_token=${ this.authToken }`;
     }
   }

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -8,8 +8,6 @@ var apiClient = new JSONAPIClient(config.host + '/api', {
   params: config.params,
 
   beforeEveryRequest: function() {
-    var { sugarClient } = require('./sugar');
-    sugarClient.refreshToken();
     var auth = require('./auth');
     return auth.checkBearerToken();
   },

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -54,6 +54,7 @@ const authClient = new Model({
     this._bearerTokenExpiration = Date.now() + (response.expires_in * 1000);
     this._refreshToken = response.refresh_token;
 
+    this.emit('refresh', this._bearerToken);
     return this._bearerToken;
   },
 

--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -15,11 +15,12 @@ if (typeof navigator !== 'undefined') {
     'Accept': 'application/json',
   }, {
     beforeEveryRequest: function() {
-      return auth.checkBearerToken()
-        .then(function (token) {
-          sugarClient.authToken = token;
-        });
+      return auth.checkBearerToken();
     }
+  });
+
+  auth.listen('refresh', function (token) {
+    sugarClient.refreshToken(token);
   });
 
   auth.listen('change', function() {
@@ -29,8 +30,7 @@ if (typeof navigator !== 'undefined') {
           sugarClient.userId = user.id;
           auth.checkBearerToken()
             .then(function (token) {
-              sugarClient.authToken = token;
-              sugarClient.connect();
+              sugarClient.refreshToken(token);
             })
 
           if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
- Emit a 'refresh' event from `auth` for each new token.
- Refactor `sugarClient.refreshToken()` to update the Sugar client token on `refresh` events.
- Reconnect to Primus when the token changes, so that the Primus URL changes.