### PR TITLE
Remove session caching

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,6 +17,7 @@ const authClient = new Model({
   _bearerTokenExpiration: NaN,
   _refreshToken: '',
   _tokenRefreshPromise: null,
+  _fetching: false,
 
   _getBearerToken: function() {
     console.log('Getting bearer token');
@@ -124,6 +125,7 @@ const authClient = new Model({
           return this.register.apply(this, originalArguments);
         }.bind(this));
       } else {
+        this._fetching = true;
         console.log('Registering new account', given.login);
         var registrationRequest = getCSRFToken(config.host).then(function(token) {
           var data = {
@@ -144,12 +146,14 @@ const authClient = new Model({
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {
+                  this._fetching = false;
                   console.info('Registered account', user.login, user.id);
                   return user;
                 });
               }.bind(this));
             }.bind(this))
             .catch(function(request) {
+              this._fetching = false;
               console.error('Failed to register');
               return apiClient.handleError(request);
             });
@@ -167,22 +171,29 @@ const authClient = new Model({
   },
 
   checkCurrent: function() {
-    if (!this._currentUserPromise) {
-      console.log('Checking current user');
-      this.update({
-        _currentUserPromise: this._getBearerToken()
-          .then(function() {
-            return this._getSession();
-          }.bind(this))
-          .catch(function() {
-            // Nobody's signed in. This isn't an error.
-            console.info('No current user');
-            return null;
-          }),
+    console.log('Checking current user (password grant)');
+    const self = this;
+    console.log('Client state', self)
+    if (!self._fetching) {
+      self._fetching = true;
+      var fetchUser = self._getBearerToken()
+        .then(self._getSession)
+        .catch(function() {
+          // Nobody's signed in. This isn't an error.
+          console.info('No current user');
+          return null;
+        })
+        .then(function (user) {
+          self._fetching = false;
+          return user;
+        });
+
+      self.update({
+        _currentUserPromise: fetchUser
       });
     }
 
-    return this._currentUserPromise;
+    return self._currentUserPromise;
   },
 
   checkBearerToken: function() {
@@ -204,6 +215,7 @@ const authClient = new Model({
         }.bind(this));
       } else {
         console.log('Signing in', credentials.login);
+        this._fetching = true;
         var signInRequest = getCSRFToken(config.host).then(function(token) {
           var url = config.host + '/users/sign_in';
 
@@ -220,12 +232,14 @@ const authClient = new Model({
             .then(function() {
               return this._getBearerToken().then(function() {
                 return this._getSession().then(function(user) {
+                  this._fetching = false;
                   console.info('Signed in', user.login, user.id);
                   return user;
                 }.bind(this));
               }.bind(this));
             }.bind(this))
             .catch(function(request) {
+              this._fetching = false;
               console.error('Failed to sign in');
               return apiClient.handleError(request);
             });

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -37,7 +37,7 @@ const authClient = new Model({
   },
 
   checkCurrent: function() {
-    console.log('Checking current user');
+    console.log('Checking current user (implicit grant)');
 
     // If we're checking for an existing session already, defer this until
     // it's finished


### PR DESCRIPTION
Remove session caching from `auth.checkCurrent()`. Instead, add a `_fetching` state which is true while a user session is being fetched from Panoptes.

This should close #207 by changing `auth.checkCurrent()` so that it always checks the Panoptes API when called, except if there is an API request already in progress.

This could be a breaking change, in that `auth.checkCurrent()` will now spam the API if it is called too frequently.