### PR TITLE
Auth module: explicitly emit 'change' events

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -147,11 +147,8 @@ const authClient = new Model({
       };
 
       const registrationRequest = this._makeRegistrationRequest(data);
-      this.update({
-        _currentUserPromise: registrationRequest.catch(function() {
-          return null;
-        }),
-      });
+      this._currentUserPromise = registrationRequest.catch(() => null);
+      this.emit('change', this._currentUserPromise);
 
       return registrationRequest;
     }
@@ -171,9 +168,8 @@ const authClient = new Model({
   async checkCurrent() {
     if (!this._currentUserPromise) {
       console.log('Checking current user');
-      this.update({
-        _currentUserPromise: this._getUser()
-      });
+      this._currentUserPromise = this._getUser();
+      this.emit('change', this._currentUserPromise);
     }
 
     return this._currentUserPromise;
@@ -221,11 +217,8 @@ const authClient = new Model({
       };
 
       const signInRequest = this._makeSignInRequest(data);
-      this.update({
-        _currentUserPromise: signInRequest.catch(function() {
-          return null;
-        }),
-      });
+      this._currentUserPromise = signInRequest.catch(() => null);
+      this.emit('change', this._currentUserPromise);
 
       return signInRequest;
     }
@@ -291,9 +284,8 @@ const authClient = new Model({
     if (user) {
       await user.delete();
       this._deleteBearerToken();
-      this.update({
-        _currentUserPromise: Promise.resolve(null),
-      });
+      this._currentUserPromise = Promise.resolve(null);
+      this.emit('change', this._currentUserPromise);
       console.info('Disabled account');
       return null;
     } else {
@@ -318,9 +310,8 @@ const authClient = new Model({
       try {
         makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders);
         this._deleteBearerToken();
-        this.update({
-          _currentUserPromise: Promise.resolve(null),
-        });
+        this._currentUserPromise = Promise.resolve(null);
+        this.emit('change', this._currentUserPromise);
         console.info('Signed out');
         return null;
       } catch (error) {


### PR DESCRIPTION
- Replace `this.update` with `this.emit` throughout the `auth` module.
- ~~Wait for API requests to resolve with a response before emitting 'change' events on sign in and on registration.~~ Waiting for promises to resolve breaks `checkCurrent()` when no one is logged in.