### PR TITLE
Bugfix: defer 'change' events on sign out

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -285,10 +285,8 @@ const authClient = new Model({
     console.log('Disabling account');
     const user = await this.checkCurrent();
     if (user) {
-      await user.delete();
       this._deleteBearerToken();
-      this._currentUserPromise = Promise.resolve(null);
-      await this._currentUserPromise;
+      this._currentUserPromise = await user.delete().then(() => null);
       this.emit('change', this._currentUserPromise);
       console.info('Disabled account');
       return null;
@@ -312,10 +310,9 @@ const authClient = new Model({
       };
 
       try {
-        makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders);
         this._deleteBearerToken();
-        this._currentUserPromise = Promise.resolve(null);
-        await this._currentUserPromise;
+        this._currentUserPromise = await makeCredentialHTTPRequest('DELETE', url, null, deleteHeaders)
+          .then(() => null);
         this.emit('change', this._currentUserPromise);
         console.info('Signed out');
         return null;


### PR DESCRIPTION
Wait for API calls to resolve before emitting `change` events on sign out. Otherwise, `change` is fired while we still have a signed-in session in Panoptes.