### PR TITLE
SugarClient: Bump Primus to 8.0.9

### DIFF
--- a/lib/SugarClient/primus.js
+++ b/lib/SugarClient/primus.js
@@ -3780,7 +3780,7 @@ Primus.prototype.decoder = function decoder(data, fn) {
 
   fn(err, data);
 };
-Primus.prototype.version = "8.0.8";
+Primus.prototype.version = "8.0.9";
 
 //
 // Expose the library.


### PR DESCRIPTION
This permanently removes the two browser hacks that were temporarily removed from Primus in #223.