### PR TITLE
add eras-client for projects stats callouts

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,11 +42,19 @@ var STAT_HOSTS = {
   test: 'https://stats-staging.zooniverse.org'
 };
 
+var ERAS_HOSTS = {
+  production: 'https://eras.zooniverse.org',
+  staging: 'https://eras-staging.zooniverse.org',
+  development: 'https://eras-staging.zooniverse.org',
+  test: 'https://eras-staging.zooniverse.org'
+};
+
 var hostFromShell = process.env.PANOPTES_API_HOST;
 var appFromShell = process.env.PANOPTES_API_APPLICATION;
 var talkFromShell = process.env.TALK_HOST;
 var sugarFromShell = process.env.SUGAR_HOST;
 var statFromShell = process.env.STAT_HOST;
+var erasFromShell = process.env.ERAS_HOST;
 var oauthFromShell = process.env.OAUTH_HOST;
 
 var envFromBrowser = locationMatch(/\W?env=(\w+)/);
@@ -88,6 +96,7 @@ module.exports = {
   talkHost: talkFromShell || TALK_HOSTS[env],
   sugarHost: sugarFromShell || SUGAR_HOSTS[env],
   statHost: statFromShell || STAT_HOSTS[env],
+  erasHost: erasFromShell || ERAS_HOSTS[env],
   oauthHost: oauthFromShell || OAUTH_HOSTS[env],
   params: defaultParams,
   jsonHeaders: JSON_HEADERS

--- a/lib/eras-client.js
+++ b/lib/eras-client.js
@@ -1,0 +1,31 @@
+var config = require('./config');
+var JSONAPIClient = require('./json-api-client');
+var makeHTTPRequest = JSONAPIClient.makeHTTPRequest;
+
+var erasClient = {
+  query: function (params) {
+    if (params.type === undefined) {
+      return Promise.reject(new Error('Missing required parameter: type (either classifications or comments) must be specified.'));
+    }
+
+    var data = {};
+    if (params.workflowID) {
+      data['workflow_id'] = params.workflowID;
+    }
+    if (params.projectID) {
+      data['project_id'] = params.projectID;
+    }
+    if (params.period) {
+      data['period'] = params.period;
+    }
+
+    var erasURL = [config.erasHost, params.type].join('/');
+
+    return makeHTTPRequest('GET', erasURL, data).then(function (response) {
+      var results = JSON.parse(response.text);
+      return results;
+    });
+  }
+};
+
+module.exports = erasClient;


### PR DESCRIPTION
Adding simple ERAS client for Project Stats Callouts. 

I mainly focused on callouts that will be used for project stats (as opposed to using statsClient on PFE). 


One thing I did not add for eras client are the future callouts that will be used. Eg. Getting classification counts by user_group (`/classifications/user_groups/:id` or getting classification count by user `/classifications/users/:id`). I figured that would be done in a future iteration when we are ready to cross that bridge. (I don't mind adding it on now if we want to have it available in PJC now). 