### PR TITLE
Changes for v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v5.6.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.6.0) (2023-11-29)
+
+* Add eras-client (erasClient) for classifications and comments statistics from [ERAS service](https://github.com/zooniverse/eras) by @yuenmichelle1 in https://github.com/zooniverse/panoptes-javascript-client/pull/227
+
+**Full Changelog**: https://github.com/zooniverse/panoptes-javascript-client/compare/v5.5.8...v5.6.0
+
+
 ## [v5.5.8](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.5.8) (2023-11-06)
 Dependency updates.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptes-client",
-  "version": "5.5.8",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptes-client",
-      "version": "5.5.8",
+      "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "5.5.8",
+  "version": "5.6.0",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
Prior releases appear to have been committed directly to `main`, but it's protected and I was not able to do that. Opening this PR accordingly.

After merge, I'll create a new tagged release on GitHub, then publish to npm.