### PR TITLE
v5.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v5.6.2](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.6.2) (2024-04-08)
+Dependency updates and bug fixes.
+
+* Bump github/codeql-action from 2 to 3 by @dependabot in https://github.com/zooniverse/panoptes-javascript-client/pull/229
+* Update README publishing instructions by @mcbouslog in https://github.com/zooniverse/panoptes-javascript-client/pull/235
+* Fix to ignore null items in API responses by @eatyourgreens in https://github.com/zooniverse/panoptes-javascript-client/pull/240
+
+**Full Changelog**: https://github.com/zooniverse/panoptes-javascript-client/compare/v5.6.1...v5.6.2
+
 ## [v5.6.1](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.6.1) (2024-02-01)
 Dependency update and tests refactors.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptes-client",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptes-client",
-      "version": "5.6.1",
+      "version": "5.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
New patch version with:
* Bump github/codeql-action from 2 to 3
* Update README publishing instructions
* Fix to ignore null items in API responses