### PR TITLE
v5.7.0: Designate the library as CJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v5.7.0](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.7.0) (2025-09-16)
+Designate the library as CJS.
+
 ## [v5.6.2](https://github.com/zooniverse/panoptes-javascript-client/tree/v5.6.2) (2024-04-08)
 Dependency updates and bug fixes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panoptes-client",
-  "version": "5.6.2",
+  "version": "5.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "panoptes-client",
-      "version": "5.6.2",
+      "version": "5.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Zooniverse",
   "license": "Apache-2.0",
   "repository": "zooniverse/panoptes-javascript-client",
+  "type": "commonjs",
   "dependencies": {
     "local-storage": "^2.0.0",
     "normalizeurl": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "panoptes-client",
-  "version": "5.6.2",
+  "version": "5.7.0",
   "description": "A Javascript client to access the Panoptes API",
   "main": "./lib/api-client.js",
   "author": "Zooniverse",


### PR DESCRIPTION
The default behaviour has changed in Node.js 20.19+, now that CommonJS has been largely replaced by ES modules in the Node package ecosystem. CommonJS packages have to explicitly specify the package type in 20.19+, if the package code uses ESM import/export syntax. PJC's source code is a mixture of ES modules and CommonJS modules, so Node infers type: module in CI unless specified otherwise in package.json.